### PR TITLE
Update agents for GitHub integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,123 @@
+# Agent Configuration
+
+This project uses Claude Code agents for automated development tasks. All agents are globally configured and can be reused across projects.
+
+## Agents
+
+### feature-analysis
+**Purpose**: Analyze GitHub issues and create implementation plans
+
+**Tools**: Glob, Grep, Read
+
+**Key Responsibilities**:
+- Reads GitHub issues from the repository
+- Reviews PROJECT_STRUCTURE.md for context
+- Creates structured implementation plans
+- Assigns work to specialized agents (backend, frontend, restassured, playwright)
+
+**GitHub Integration**: Uses `gh` CLI to fetch issues
+
+### backend
+**Purpose**: Build and modify Spring Boot REST API modules
+
+**Tools**: Glob, Grep, Read, Write, Edit, Bash
+
+**Responsibilities**:
+- Implements REST endpoints
+- Creates/updates JPA entities and DTOs
+- Configures security and Swagger documentation
+- Updates Maven configuration
+
+### frontend
+**Purpose**: Build and modify Next.js frontend modules
+
+**Tools**: Glob, Grep, Read, Write, Edit, Bash
+
+**Responsibilities**:
+- Implements React components with TypeScript
+- Configures Tailwind CSS styling
+- Uses shadcn/ui component library
+- Manages Next.js routing and pages
+
+### restassured
+**Purpose**: Write and update RestAssured integration tests
+
+**Tools**: Glob, Grep, Read, Write, Edit, Bash
+
+**Responsibilities**:
+- Creates REST API integration test suites
+- Uses builder pattern for test data
+- Implements functional flow testing
+- Maintains test quality metrics
+
+### mutation-testing
+**Purpose**: Run PIT mutation tests and improve coverage
+
+**Tools**: Glob, Grep, Read, Write, Edit, Bash
+
+**Responsibilities**:
+- Executes mutation testing on backend code
+- Coordinates with restassured agent to improve coverage
+- Validates mutation score against 80% target
+- Generates mutation test reports
+
+### playwright
+**Purpose**: Write and update Playwright e2e tests
+
+**Tools**: Glob, Grep, Read, Write, Edit, Bash
+
+**Responsibilities**:
+- Implements end-to-end tests for frontend flows
+- Uses Page Object Model pattern
+- Tests Next.js frontend functionality
+- Creates browser screenshots and logs
+
+## GitHub Integration
+
+All agents use the GitHub CLI (`gh`) for repository operations:
+
+```bash
+# Fetch issues
+gh issue view <number>
+
+# List issues
+gh issue list
+
+# Create issues
+gh issue create --title "..." --body "..."
+
+# Create pull requests
+gh pr create --title "..." --body "..."
+```
+
+**Required scopes**: `repo`, `read:org`, `workflow`
+
+To refresh GitHub authentication:
+```bash
+gh auth refresh -s repo read:org workflow
+```
+
+## Agent Configuration Location
+
+Global agents are stored in `~/.claude/agents/`:
+- `feature-analysis.md`
+- `backend.md`
+- `frontend.md`
+- `restassured.md`
+- `playwright.md`
+- `mutation-testing.md`
+
+These are shared across all projects and should not be modified per-project.
+
+## Usage
+
+Agents are triggered via the Agent tool:
+
+```
+@claude "Use the feature-analysis agent to plan Issue #5"
+```
+
+Or directly by specialist:
+```
+@claude "Use the backend agent to implement the registration endpoint"
+```


### PR DESCRIPTION
## Summary
- Update agents to support GitHub instead of GitLab
- feature-analysis agent now reads GitHub issues (uses gh CLI)
- Add AGENTS.md documentation for agent configuration
- All agents are globally configured in ~/.claude/agents/

## Changes
- ✅ feature-analysis agent: Updated to use GitHub issues
- ✅ Add AGENTS.md: Documents all agents and GitHub integration
- ✅ Removed GitLab MCP references (now use gh CLI)

## Benefits
- All agents work with GitHub issues and PRs
- Consistent with project migration to GitHub
- Agents remain generic and reusable across projects
- GitHub CLI integration provides full API access

## Notes
- Global agents in ~/.claude/agents/ are project-agnostic
- feature-analysis now uses `gh issue view` for GitHub issues
- No breaking changes to other agents (backend, frontend, etc.)