### PR TITLE
Fix: Handle zero mutations in generate-report script

### DIFF
--- a/scripts/generate-report.py
+++ b/scripts/generate-report.py
@@ -295,7 +295,7 @@ def generate_html_report(tests, mutations):
             <div class="metric-card">
                 <h3>Mutations Killed</h3>
                 <div class="metric-value">{total_killed}/{total_mutations}</div>
-                <span class="badge pass">{round(total_killed/total_mutations*100, 1)}% Coverage</span>
+                <span class="badge pass">{round(total_killed/total_mutations*100, 1) if total_mutations > 0 else 0}% Coverage</span>
             </div>
         </div>
 


### PR DESCRIPTION
Prevent ZeroDivisionError when total_mutations is 0 by checking before calculating coverage percentage.