### PR TITLE
fix: Ensure username field is always included in LoginResponse JSON

### DIFF
--- a/backend/src/main/java/techchamps/io/dto/response/LoginResponse.java
+++ b/backend/src/main/java/techchamps/io/dto/response/LoginResponse.java
@@ -1,5 +1,6 @@
 package techchamps.io.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "Login response payload")
@@ -11,6 +12,7 @@ public class LoginResponse {
     @Schema(description = "Human-readable result message", example = "Login successful")
     private String message;
 
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     @Schema(description = "Username of the authenticated user (null when login fails)", example = "user", nullable = true)
     private String username;
 


### PR DESCRIPTION
## Problem
CI test failures: 3 out of 49 RestAssured tests fail intermittently

**Error:**
```
JSON path username doesn't match.
Expected: user
Actual: null
```

Tests:
- `AuthControllerIT.login_happyPath_returns200AndSuccessTrue`
- `AuthControllerIT.login_happyPath_responseMessageIsLoginSuccessful`
- `AuthControllerIntegrationTest.loginWithValidCredentials_shouldReturn200AndSuccessTrue`

## Root Cause
The `username` field in LoginResponse was not being included in the JSON response in certain conditions. RestAssured couldn't find the field and defaulted to `null`, causing the assertions to fail.

## Solution
Added `@JsonInclude(JsonInclude.Include.ALWAYS)` annotation to the `username` field in LoginResponse DTO to guarantee the field is always present in the JSON serialization, even when the value is `null`.

This ensures RestAssured can always find the field and properly deserialize it.

## Files Changed
- `backend/src/main/java/techchamps/io/dto/response/LoginResponse.java` - Added @JsonInclude annotation