### PR TITLE
fix: Add @BeforeEach setup to ensure seed user exists in auth tests

### DIFF
--- a/restassured-tests/src/test/java/techchamps/io/AuthControllerIT.java
+++ b/restassured-tests/src/test/java/techchamps/io/AuthControllerIT.java
@@ -4,6 +4,7 @@ import techchamps.io.builder.LoginRequestBuilder;
 import techchamps.io.dto.request.LoginRequest;
 import techchamps.io.dto.response.LoginResponse;
 import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -18,6 +19,22 @@ import static org.hamcrest.Matchers.nullValue;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DisplayName("POST /api/auth/login")
 class AuthControllerIT extends BaseIntegrationTest {
+
+    // ---------------------------------------------------------------
+    // Setup: Ensure seed user exists before tests
+    // ---------------------------------------------------------------
+
+    @BeforeEach
+    void ensureSeedUserExists() {
+        given()
+            .port(port)
+            .contentType(ContentType.JSON)
+            .body(new LoginRequestBuilder().build())
+        .when()
+            .post("/api/auth/login")
+        .then()
+            .statusCode(200);
+    }
 
     // ---------------------------------------------------------------
     // Happy path

--- a/restassured-tests/src/test/java/techchamps/io/controller/AuthControllerIntegrationTest.java
+++ b/restassured-tests/src/test/java/techchamps/io/controller/AuthControllerIntegrationTest.java
@@ -3,6 +3,7 @@ package techchamps.io.controller;
 import techchamps.io.BaseIntegrationTest;
 import techchamps.io.builder.LoginRequestBuilder;
 import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -20,6 +21,18 @@ import static org.hamcrest.Matchers.nullValue;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DisplayName("AuthController – basis smoke tests")
 class AuthControllerIntegrationTest extends BaseIntegrationTest {
+
+    @BeforeEach
+    void ensureSeedUserExists() {
+        given()
+            .port(port)
+            .contentType(ContentType.JSON)
+            .body(new LoginRequestBuilder().build())
+        .when()
+            .post("/api/auth/login")
+        .then()
+            .statusCode(200);
+    }
 
     @Test
     @Order(1)


### PR DESCRIPTION
## Problem
AuthController tests were failing because the seed user 'user' didn't exist in the H2 in-memory database.

**Root cause:**
- `AuthControllerIT` and `AuthControllerIntegrationTest` test classes had no setup
- Other test classes like `SecurityConfigIT` have a `@BeforeEach` that ensures the user exists
- When tests run, the DataInitializer may not have initialized the database yet
- Tests fail with 401 Unauthorized because authentication can't find the user

## Solution
Added `@BeforeEach` methods to both test classes that call the login endpoint before each test. This ensures:
1. The DataInitializer runs and creates the seed user
2. The H2 database is properly initialized
3. Subsequent tests can authenticate with valid credentials

## Files Changed
- `restassured-tests/src/test/java/techchamps/io/AuthControllerIT.java` - Added @BeforeEach
- `restassured-tests/src/test/java/techchamps/io/controller/AuthControllerIntegrationTest.java` - Added @BeforeEach

This matches the pattern used in `SecurityConfigIT` which has the same requirement.