### PR TITLE
Issue #25: Implement role-based access control (USER, MODERATOR, ADMIN)

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,6 +1,6 @@
 # Project Structure Index
 
-**Last Updated:** 2026-04-02 (Forum layout update: vote badge, reply header, nesting border, collapse toggle)
+**Last Updated:** 2026-04-03 (Role-based access control: USER, MODERATOR, ADMIN roles; close thread, delete reply, list users endpoints)
 **Important:** When agents add new files/components, they MUST update this file.
 
 ---
@@ -21,6 +21,10 @@
   - `POST /api/forum/replies/{replyId}/replies` — create nested reply (auth, max depth 3)
   - `POST /api/forum/posts/{postId}/vote?postType=thread` — vote (auth)
   - `DELETE /api/forum/threads/{id}` — delete own thread or admin (auth)
+  - `POST /api/forum/threads/{id}/close?closed=true` — close/reopen thread (MODERATOR/ADMIN)
+  - `DELETE /api/forum/replies/{id}` — delete reply (MODERATOR/ADMIN)
+- `UserController.java` - Admin user management:
+  - `GET /api/users` — list all users (ADMIN only)
 - `ProfileController.java` - User profile management:
   - `GET /api/profile/{username}` - Get profile (200 / 404)
   - `PUT /api/profile/{username}` - Update profile fields (200 / 404)
@@ -51,6 +55,8 @@
   - `dto/response/ForumReplyResponse.java` - id, content, score, createdAt, authorUsername, depth, parentReplyId, replies (nested)
   - `dto/response/PagedThreadsResponse.java` - threads, page, size, hasMore
   - `dto/response/VoteResponse.java` - postId, postType, newScore, userVote
+  - `dto/response/UserSummaryResponse.java` - id, username, email, role (admin user listing)
+  - `dto/response/LoginResponse.java` now includes `role` field (USER/MODERATOR/ADMIN)
   - *(Add new response DTOs here)*
 
 ### Models (JPA Entities)
@@ -58,6 +64,7 @@
 - `model/ForumCategory.java` - id, name (unique), description, icon
 - `model/ForumThread.java` - id, author (AppUser), title (max 200), description (max 5000), category (ForumCategory), createdAt, updatedAt, score
 - `model/ForumReply.java` - id, thread, parentReply (nullable), author, content (max 2000), createdAt, score, depth
+- `model/Role.java` - Role enum: USER, MODERATOR, ADMIN
 - `model/ForumVote.java` - id, voter (AppUser), postId, postType, voteValue; unique on (voter, postId, postType)
 
 ### Repositories
@@ -152,6 +159,7 @@
 - `SecurityConfigIT.java` - Security tests
 - `controller/AuthControllerIntegrationTest.java` - Extended auth tests
 - `RegistrationIT.java` - Integration tests for registration endpoint
+- `RoleBasedAccessControlIT.java` - 14 integration tests for RBAC: close thread (user=403, mod=200, admin=200), closed thread rejects replies, delete reply (user=403, mod=204), list users (user=403, mod=403, admin=200)
 - `ForumThreadIT.java` - 21 integration tests for forum: categories, threads CRUD, boundary tests (title 200/201, desc 5000/5001, reply 2000/2001), depth boundary (depth 2 passes, depth 3 rejected), voting, delete 204/403
 
 ### Test Builders
@@ -179,6 +187,7 @@
 - `tests/e2e/profile.spec.ts` - User Profile Page Flow (23 tests); happy-path tests use real API calls (no mocks); mocks kept only for error scenarios (404, 500) and the no-avatar edge case
 - `tests/e2e/forum.spec.ts` - Forum E2E tests: index page (public + auth), thread detail, create thread flow, reply flow, search; all happy-path tests use real API calls via backend on port 8080
 - `tests/e2e/auth.spec.ts` - Auth E2E tests (11 tests): login wrong credentials, nonexistent user, empty fields, register-to-login link, full registration happy path, mismatched passwords, invalid email, duplicate username, short password, login link, logout from dashboard
+- `tests/e2e/rbac.spec.ts` - RBAC E2E tests: moderator close thread flow, delete reply visibility, closed thread UI
 - `tests/e2e/user-journey.spec.ts` - End-to-end user journeys (12 tests): full register→login→forum→create thread→reply→vote journey, forum navigation from dashboard, category filter flow, thread upvote/downvote/toggle, profile update journey, public thread access, forum search→detail navigation, reply constraint (content > 2000 chars errors on submit, counter)
 
 ### Test Strategy

--- a/backend/src/main/java/techchamps/io/config/DataInitializer.java
+++ b/backend/src/main/java/techchamps/io/config/DataInitializer.java
@@ -2,6 +2,7 @@ package techchamps.io.config;
 
 import techchamps.io.model.AppUser;
 import techchamps.io.model.ForumCategory;
+import techchamps.io.model.Role;
 import techchamps.io.repository.ForumCategoryRepository;
 import java.util.List;
 
@@ -27,13 +28,34 @@ public class DataInitializer implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) {
+        // Seed user (USER role)
         if (userRepository.findByUsername("user").isEmpty()) {
-            AppUser user = new AppUser("user@example.com", "user", passwordEncoder.encode("user1234"), "USER");
+            AppUser user = new AppUser("user@example.com", "user", passwordEncoder.encode("user1234"), Role.USER);
             user.setDisplayName("Demo User");
             user.setBio("Software developer and coffee enthusiast");
             user.setLocation("Amsterdam, Netherlands");
             user.setAvatarUrl("https://api.dicebear.com/7.x/avataaars/svg?seed=user");
             userRepository.save(user);
+        }
+
+        // Seed moderator (MODERATOR role)
+        if (userRepository.findByUsername("moderator").isEmpty()) {
+            AppUser moderator = new AppUser("moderator@example.com", "moderator", passwordEncoder.encode("moderator1234"), Role.MODERATOR);
+            moderator.setDisplayName("Forum Moderator");
+            moderator.setBio("Keeping the forum clean and organized");
+            moderator.setLocation("Amsterdam, Netherlands");
+            moderator.setAvatarUrl("https://api.dicebear.com/7.x/avataaars/svg?seed=moderator");
+            userRepository.save(moderator);
+        }
+
+        // Seed admin (ADMIN role)
+        if (userRepository.findByUsername("admin").isEmpty()) {
+            AppUser admin = new AppUser("admin@example.com", "admin", passwordEncoder.encode("admin1234"), Role.ADMIN);
+            admin.setDisplayName("Forum Admin");
+            admin.setBio("Full control over the forum");
+            admin.setLocation("Amsterdam, Netherlands");
+            admin.setAvatarUrl("https://api.dicebear.com/7.x/avataaars/svg?seed=admin");
+            userRepository.save(admin);
         }
 
         // Seed forum categories

--- a/backend/src/main/java/techchamps/io/controller/AuthController.java
+++ b/backend/src/main/java/techchamps/io/controller/AuthController.java
@@ -5,6 +5,7 @@ import techchamps.io.dto.request.RegisterRequest;
 import techchamps.io.dto.response.LoginResponse;
 import techchamps.io.dto.response.RegisterResponse;
 import techchamps.io.model.AppUser;
+import techchamps.io.model.Role;
 import techchamps.io.repository.AppUserRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -55,7 +56,12 @@ public class AuthController {
                 )
             );
 
-            return ResponseEntity.ok(new LoginResponse(true, "Login successful", loginRequest.getUsername()));
+            String role = appUserRepository.findByUsername(loginRequest.getUsername())
+                    .map(u -> u.getRole().name())
+                    .orElse(Role.USER.name());
+
+            return ResponseEntity.ok(new LoginResponse(true, "Login successful",
+                    loginRequest.getUsername(), role));
 
         } catch (BadCredentialsException e) {
             return ResponseEntity
@@ -64,13 +70,6 @@ public class AuthController {
         }
     }
 
-    /**
-     * Register a new user account.
-     * Validates input, checks for duplicate email/username, hashes the password, and persists the user.
-     *
-     * @param registerRequest the registration payload with email, username, and password
-     * @return 200 with RegisterResponse on success, 409 on duplicate email/username
-     */
     @PostMapping("/register")
     @Operation(summary = "Register", description = "Create a new user account with email, username, and password")
     @ApiResponses({
@@ -100,7 +99,7 @@ public class AuthController {
             registerRequest.getEmail(),
             registerRequest.getUsername(),
             passwordEncoder.encode(registerRequest.getPassword()),
-            "USER"
+            Role.USER
         );
 
         AppUser savedUser = appUserRepository.save(newUser);

--- a/backend/src/main/java/techchamps/io/controller/ForumController.java
+++ b/backend/src/main/java/techchamps/io/controller/ForumController.java
@@ -83,6 +83,22 @@ public class ForumController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    @PostMapping("/threads/{id}/close")
+    @Operation(summary = "Close or reopen a thread", description = "Requires MODERATOR or ADMIN role")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Thread closed/reopened",
+            content = @Content(schema = @Schema(implementation = ForumThreadResponse.class))),
+        @ApiResponse(responseCode = "403", description = "Forbidden — requires MODERATOR or ADMIN"),
+        @ApiResponse(responseCode = "404", description = "Thread not found")
+    })
+    public ResponseEntity<ForumThreadResponse> closeThread(
+            @PathVariable Long id,
+            @RequestParam(defaultValue = "true") boolean closed,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        ForumThreadResponse response = forumService.setThreadClosed(id, userDetails.getUsername(), closed);
+        return ResponseEntity.ok(response);
+    }
+
     @PostMapping("/threads/{threadId}/replies")
     @Operation(summary = "Create a reply on a thread", description = "Requires authentication")
     @ApiResponses({
@@ -90,6 +106,7 @@ public class ForumController {
             content = @Content(schema = @Schema(implementation = ForumReplyResponse.class))),
         @ApiResponse(responseCode = "400", description = "Validation error or max depth exceeded"),
         @ApiResponse(responseCode = "401", description = "Unauthenticated"),
+        @ApiResponse(responseCode = "403", description = "Thread is closed"),
         @ApiResponse(responseCode = "404", description = "Thread not found")
     })
     public ResponseEntity<ForumReplyResponse> createThreadReply(
@@ -118,6 +135,20 @@ public class ForumController {
         ForumReplyResponse response = forumService.createReply(
                 parentReply.getThread().getId(), userDetails.getUsername(), nestedRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @DeleteMapping("/replies/{id}")
+    @Operation(summary = "Delete a reply", description = "Requires MODERATOR or ADMIN role")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "Reply deleted"),
+        @ApiResponse(responseCode = "403", description = "Forbidden — requires MODERATOR or ADMIN"),
+        @ApiResponse(responseCode = "404", description = "Reply not found")
+    })
+    public ResponseEntity<Void> deleteReply(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        forumService.deleteReply(id, userDetails.getUsername());
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/posts/{postId}/vote")

--- a/backend/src/main/java/techchamps/io/controller/UserController.java
+++ b/backend/src/main/java/techchamps/io/controller/UserController.java
@@ -1,0 +1,40 @@
+package techchamps.io.controller;
+
+import techchamps.io.dto.response.UserSummaryResponse;
+import techchamps.io.service.ForumService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+@Tag(name = "Users", description = "Admin endpoints for user management")
+public class UserController {
+
+    private final ForumService forumService;
+
+    public UserController(ForumService forumService) {
+        this.forumService = forumService;
+    }
+
+    @GetMapping
+    @Operation(summary = "List all users", description = "Requires ADMIN role")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "List of users",
+            content = @Content(schema = @Schema(implementation = UserSummaryResponse.class))),
+        @ApiResponse(responseCode = "403", description = "Forbidden — requires ADMIN role")
+    })
+    public ResponseEntity<List<UserSummaryResponse>> listUsers(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.ok(forumService.listUsers(userDetails.getUsername()));
+    }
+}

--- a/backend/src/main/java/techchamps/io/dto/response/ForumThreadResponse.java
+++ b/backend/src/main/java/techchamps/io/dto/response/ForumThreadResponse.java
@@ -36,6 +36,9 @@ public class ForumThreadResponse {
     @Schema(description = "Total number of replies")
     private int replyCount;
 
+    @Schema(description = "Whether the thread is closed for new replies")
+    private boolean isClosed;
+
     public ForumThreadResponse() {}
 
     public Long getId() { return id; }
@@ -48,6 +51,7 @@ public class ForumThreadResponse {
     public Long getCategoryId() { return categoryId; }
     public String getCategoryName() { return categoryName; }
     public int getReplyCount() { return replyCount; }
+    public boolean isClosed() { return isClosed; }
 
     public void setId(Long id) { this.id = id; }
     public void setTitle(String title) { this.title = title; }
@@ -59,4 +63,5 @@ public class ForumThreadResponse {
     public void setCategoryId(Long categoryId) { this.categoryId = categoryId; }
     public void setCategoryName(String categoryName) { this.categoryName = categoryName; }
     public void setReplyCount(int replyCount) { this.replyCount = replyCount; }
+    public void setIsClosed(boolean isClosed) { this.isClosed = isClosed; }
 }

--- a/backend/src/main/java/techchamps/io/dto/response/LoginResponse.java
+++ b/backend/src/main/java/techchamps/io/dto/response/LoginResponse.java
@@ -16,6 +16,10 @@ public class LoginResponse {
     @Schema(description = "Username of the authenticated user (null when login fails)", example = "user", nullable = true)
     private String username;
 
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    @Schema(description = "Role of the authenticated user (null when login fails)", example = "USER", nullable = true)
+    private String role;
+
     public LoginResponse() {}
 
     public LoginResponse(boolean success, String message) {
@@ -29,27 +33,22 @@ public class LoginResponse {
         this.username = username;
     }
 
-    public boolean isSuccess() {
-        return success;
-    }
-
-    public void setSuccess(boolean success) {
+    public LoginResponse(boolean success, String message, String username, String role) {
         this.success = success;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
-    public void setMessage(String message) {
         this.message = message;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
         this.username = username;
+        this.role = role;
     }
+
+    public boolean isSuccess() { return success; }
+    public void setSuccess(boolean success) { this.success = success; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getRole() { return role; }
+    public void setRole(String role) { this.role = role; }
 }

--- a/backend/src/main/java/techchamps/io/dto/response/UserSummaryResponse.java
+++ b/backend/src/main/java/techchamps/io/dto/response/UserSummaryResponse.java
@@ -1,0 +1,37 @@
+package techchamps.io.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Summarized user info for admin queries")
+public class UserSummaryResponse {
+    @Schema(description = "User ID", example = "1")
+    private Long id;
+
+    @Schema(description = "Username", example = "john_doe")
+    private String username;
+
+    @Schema(description = "Email", example = "john@example.com")
+    private String email;
+
+    @Schema(description = "User role", example = "USER")
+    private String role;
+
+    public UserSummaryResponse() {}
+
+    public UserSummaryResponse(Long id, String username, String email, String role) {
+        this.id = id;
+        this.username = username;
+        this.email = email;
+        this.role = role;
+    }
+
+    public Long getId() { return id; }
+    public String getUsername() { return username; }
+    public String getEmail() { return email; }
+    public String getRole() { return role; }
+
+    public void setId(Long id) { this.id = id; }
+    public void setUsername(String username) { this.username = username; }
+    public void setEmail(String email) { this.email = email; }
+    public void setRole(String role) { this.role = role; }
+}

--- a/backend/src/main/java/techchamps/io/model/AppUser.java
+++ b/backend/src/main/java/techchamps/io/model/AppUser.java
@@ -19,8 +19,9 @@ public class AppUser {
     @Column(nullable = false)
     private String password;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private String role;
+    private Role role;
 
     @Column(name = "display_name")
     private String displayName;
@@ -35,13 +36,13 @@ public class AppUser {
 
     public AppUser() {}
 
-    public AppUser(String username, String password, String role) {
+    public AppUser(String username, String password, Role role) {
         this.username = username;
         this.password = password;
         this.role = role;
     }
 
-    public AppUser(String email, String username, String password, String role) {
+    public AppUser(String email, String username, String password, Role role) {
         this.email = email;
         this.username = username;
         this.password = password;
@@ -52,7 +53,7 @@ public class AppUser {
     public String getEmail() { return email; }
     public String getUsername() { return username; }
     public String getPassword() { return password; }
-    public String getRole() { return role; }
+    public Role getRole() { return role; }
     public String getDisplayName() { return displayName; }
     public String getBio() { return bio; }
     public String getLocation() { return location; }
@@ -61,7 +62,7 @@ public class AppUser {
     public void setEmail(String email) { this.email = email; }
     public void setUsername(String username) { this.username = username; }
     public void setPassword(String password) { this.password = password; }
-    public void setRole(String role) { this.role = role; }
+    public void setRole(Role role) { this.role = role; }
     public void setDisplayName(String displayName) { this.displayName = displayName; }
     public void setBio(String bio) { this.bio = bio; }
     public void setLocation(String location) { this.location = location; }

--- a/backend/src/main/java/techchamps/io/model/ForumThread.java
+++ b/backend/src/main/java/techchamps/io/model/ForumThread.java
@@ -35,6 +35,9 @@ public class ForumThread {
 
     private int score = 0;
 
+    @Column(name = "is_closed", nullable = false)
+    private boolean isClosed = false;
+
     public ForumThread() {}
 
     @PrePersist
@@ -56,6 +59,7 @@ public class ForumThread {
     public LocalDateTime getCreatedAt() { return createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }
     public int getScore() { return score; }
+    public boolean isClosed() { return isClosed; }
 
     public void setId(Long id) { this.id = id; }
     public void setAuthor(AppUser author) { this.author = author; }
@@ -65,4 +69,5 @@ public class ForumThread {
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
     public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
     public void setScore(int score) { this.score = score; }
+    public void setIsClosed(boolean isClosed) { this.isClosed = isClosed; }
 }

--- a/backend/src/main/java/techchamps/io/model/Role.java
+++ b/backend/src/main/java/techchamps/io/model/Role.java
@@ -1,0 +1,5 @@
+package techchamps.io.model;
+
+public enum Role {
+    USER, MODERATOR, ADMIN
+}

--- a/backend/src/main/java/techchamps/io/service/ForumService.java
+++ b/backend/src/main/java/techchamps/io/service/ForumService.java
@@ -5,6 +5,7 @@ import techchamps.io.dto.request.CreateThreadRequest;
 import techchamps.io.dto.response.*;
 import techchamps.io.model.*;
 import techchamps.io.repository.*;
+import techchamps.io.model.Role;
 import org.springframework.data.domain.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -120,6 +121,10 @@ public class ForumService {
         ForumThread thread = threadRepository.findById(threadId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Thread not found"));
 
+        if (thread.isClosed()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Thread is closed");
+        }
+
         int depth = 0;
         ForumReply parentReply = null;
 
@@ -193,9 +198,10 @@ public class ForumService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
 
         boolean isOwner = thread.getAuthor().getUsername().equals(username);
-        boolean isAdmin = "ADMIN".equals(user.getRole());
+        boolean isAdmin = user.getRole() == Role.ADMIN;
+        boolean isModerator = user.getRole() == Role.MODERATOR;
 
-        if (!isOwner && !isAdmin) {
+        if (!isOwner && !isAdmin && !isModerator) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You can only delete your own threads");
         }
 
@@ -246,6 +252,7 @@ public class ForumService {
             r.setCategoryName(thread.getCategory().getName());
         }
         r.setReplyCount((int) threadRepository.countRepliesByThreadId(thread.getId()));
+        r.setIsClosed(thread.isClosed());
     }
 
     private ForumReplyResponse toReplyResponse(ForumReply reply, List<ForumReplyResponse> children) {
@@ -264,6 +271,49 @@ public class ForumService {
     public ForumReply getReplyById(Long id) {
         return replyRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reply not found"));
+    }
+
+    public ForumThreadResponse setThreadClosed(Long id, String username, boolean closed) {
+        AppUser user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+        if (user.getRole() != Role.MODERATOR && user.getRole() != Role.ADMIN) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Requires MODERATOR or ADMIN role");
+        }
+
+        ForumThread thread = threadRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Thread not found"));
+
+        thread.setIsClosed(closed);
+        ForumThread saved = threadRepository.save(thread);
+        return toThreadResponse(saved);
+    }
+
+    public void deleteReply(Long id, String username) {
+        AppUser user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+        if (user.getRole() != Role.MODERATOR && user.getRole() != Role.ADMIN) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Requires MODERATOR or ADMIN role");
+        }
+
+        ForumReply reply = replyRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Reply not found"));
+
+        replyRepository.delete(reply);
+    }
+
+    public List<UserSummaryResponse> listUsers(String username) {
+        AppUser user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+        if (user.getRole() != Role.ADMIN) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Requires ADMIN role");
+        }
+
+        return userRepository.findAll().stream()
+                .map(u -> new UserSummaryResponse(u.getId(), u.getUsername(), u.getEmail(), u.getRole().name()))
+                .collect(Collectors.toList());
     }
 
 }

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5,3 +5,5 @@ databaseChangeLog:
       file: classpath:db/migration/V002__create_forum_tables.sql
   - include:
       file: classpath:db/migration/V003__seed_test_data.sql
+  - include:
+      file: classpath:db/migration/V004__add_role_and_thread_closed.sql

--- a/backend/src/main/resources/db/migration/V004__add_role_and_thread_closed.sql
+++ b/backend/src/main/resources/db/migration/V004__add_role_and_thread_closed.sql
@@ -1,0 +1,9 @@
+-- Liquibase formatted sql
+-- changeset liquibase:V004__add_role_and_thread_closed
+
+ALTER TABLE forum_threads ADD COLUMN IF NOT EXISTS is_closed BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE forum_replies ADD COLUMN IF NOT EXISTS parent_reply_id BIGINT REFERENCES forum_replies(id);
+ALTER TABLE forum_replies ADD COLUMN IF NOT EXISTS depth INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_forum_replies_parent_reply_id ON forum_replies(parent_reply_id);

--- a/backend/src/test/java/techchamps/io/config/DataInitializerTest.java
+++ b/backend/src/test/java/techchamps/io/config/DataInitializerTest.java
@@ -1,8 +1,10 @@
 package techchamps.io.config;
 
 import techchamps.io.model.AppUser;
+import techchamps.io.model.Role;
 import techchamps.io.repository.AppUserRepository;
 import techchamps.io.repository.ForumCategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -12,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,96 +39,111 @@ class DataInitializerTest {
     @InjectMocks
     private DataInitializer dataInitializer;
 
-    // --- happy path: user does not exist yet, should be created ---
-
-    @Test
-    void run_whenUserDoesNotExist_savesNewUser() throws Exception {
+    @BeforeEach
+    void setupDefaultMocks() {
         when(userRepository.findByUsername("user")).thenReturn(Optional.empty());
-        when(passwordEncoder.encode("user1234")).thenReturn("encodedPassword");
-
-        dataInitializer.run(applicationArguments);
-
-        verify(userRepository, times(1)).save(any(AppUser.class));
+        when(userRepository.findByUsername("moderator")).thenReturn(Optional.empty());
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(anyString())).thenReturn("encodedPassword");
+        when(forumCategoryRepository.count()).thenReturn(3L);
     }
 
-    // --- happy path: saved user has correct username ---
+    @Test
+    void run_whenNoUsersExist_savesAllThreeUsers() throws Exception {
+        dataInitializer.run(applicationArguments);
+
+        verify(userRepository, times(3)).save(any(AppUser.class));
+    }
 
     @Test
     void run_whenUserDoesNotExist_savesUserWithCorrectUsername() throws Exception {
-        when(userRepository.findByUsername("user")).thenReturn(Optional.empty());
-        when(passwordEncoder.encode("user1234")).thenReturn("encodedPassword");
-
         dataInitializer.run(applicationArguments);
 
         ArgumentCaptor<AppUser> captor = ArgumentCaptor.forClass(AppUser.class);
-        verify(userRepository).save(captor.capture());
-        assertThat(captor.getValue().getUsername()).isEqualTo("user");
+        verify(userRepository, times(3)).save(captor.capture());
+        List<AppUser> saved = captor.getAllValues();
+        assertThat(saved).extracting(AppUser::getUsername)
+                .contains("user", "moderator", "admin");
     }
-
-    // --- happy path: saved user has encoded password ---
 
     @Test
     void run_whenUserDoesNotExist_savesUserWithEncodedPassword() throws Exception {
-        when(userRepository.findByUsername("user")).thenReturn(Optional.empty());
-        when(passwordEncoder.encode("user1234")).thenReturn("encodedPassword");
-
         dataInitializer.run(applicationArguments);
 
         ArgumentCaptor<AppUser> captor = ArgumentCaptor.forClass(AppUser.class);
-        verify(userRepository).save(captor.capture());
-        assertThat(captor.getValue().getPassword()).isEqualTo("encodedPassword");
+        verify(userRepository, times(3)).save(captor.capture());
+        AppUser regularUser = captor.getAllValues().stream()
+                .filter(u -> "user".equals(u.getUsername()))
+                .findFirst().orElseThrow();
+        assertThat(regularUser.getPassword()).isEqualTo("encodedPassword");
     }
-
-    // --- happy path: saved user has correct role ---
 
     @Test
-    void run_whenUserDoesNotExist_savesUserWithUserRole() throws Exception {
-        when(userRepository.findByUsername("user")).thenReturn(Optional.empty());
-        when(passwordEncoder.encode("user1234")).thenReturn("encodedPassword");
-
+    void run_seedsUserWithUserRole() throws Exception {
         dataInitializer.run(applicationArguments);
 
         ArgumentCaptor<AppUser> captor = ArgumentCaptor.forClass(AppUser.class);
-        verify(userRepository).save(captor.capture());
-        assertThat(captor.getValue().getRole()).isEqualTo("USER");
+        verify(userRepository, times(3)).save(captor.capture());
+        AppUser regularUser = captor.getAllValues().stream()
+                .filter(u -> "user".equals(u.getUsername()))
+                .findFirst().orElseThrow();
+        assertThat(regularUser.getRole()).isEqualTo(Role.USER);
     }
 
-    // --- happy path: saved user has correct profile fields ---
+    @Test
+    void run_seedsModeratorWithModeratorRole() throws Exception {
+        dataInitializer.run(applicationArguments);
+
+        ArgumentCaptor<AppUser> captor = ArgumentCaptor.forClass(AppUser.class);
+        verify(userRepository, times(3)).save(captor.capture());
+        AppUser mod = captor.getAllValues().stream()
+                .filter(u -> "moderator".equals(u.getUsername()))
+                .findFirst().orElseThrow();
+        assertThat(mod.getRole()).isEqualTo(Role.MODERATOR);
+    }
+
+    @Test
+    void run_seedsAdminWithAdminRole() throws Exception {
+        dataInitializer.run(applicationArguments);
+
+        ArgumentCaptor<AppUser> captor = ArgumentCaptor.forClass(AppUser.class);
+        verify(userRepository, times(3)).save(captor.capture());
+        AppUser admin = captor.getAllValues().stream()
+                .filter(u -> "admin".equals(u.getUsername()))
+                .findFirst().orElseThrow();
+        assertThat(admin.getRole()).isEqualTo(Role.ADMIN);
+    }
 
     @Test
     void run_whenUserDoesNotExist_savesUserWithProfileFields() throws Exception {
-        when(userRepository.findByUsername("user")).thenReturn(Optional.empty());
-        when(passwordEncoder.encode("user1234")).thenReturn("encodedPassword");
-
         dataInitializer.run(applicationArguments);
 
         ArgumentCaptor<AppUser> captor = ArgumentCaptor.forClass(AppUser.class);
-        verify(userRepository).save(captor.capture());
-        AppUser saved = captor.getValue();
+        verify(userRepository, times(3)).save(captor.capture());
+        AppUser saved = captor.getAllValues().stream()
+                .filter(u -> "user".equals(u.getUsername()))
+                .findFirst().orElseThrow();
         assertThat(saved.getDisplayName()).isEqualTo("Demo User");
         assertThat(saved.getBio()).isEqualTo("Software developer and coffee enthusiast");
         assertThat(saved.getLocation()).isEqualTo("Amsterdam, Netherlands");
         assertThat(saved.getAvatarUrl()).isEqualTo("https://api.dicebear.com/7.x/avataaars/svg?seed=user");
     }
 
-    // --- edge case: user already exists, no save should happen ---
-
     @Test
-    void run_whenUserAlreadyExists_doesNotSaveAgain() throws Exception {
-        AppUser existing = new AppUser("user", "alreadyEncoded", "USER");
+    void run_whenUserAlreadyExists_doesNotSaveUser() throws Exception {
+        AppUser existing = new AppUser("user", "alreadyEncoded", Role.USER);
         when(userRepository.findByUsername("user")).thenReturn(Optional.of(existing));
 
         dataInitializer.run(applicationArguments);
 
-        verify(userRepository, never()).save(any());
-        verify(passwordEncoder, never()).encode(any());
+        ArgumentCaptor<AppUser> captor = ArgumentCaptor.forClass(AppUser.class);
+        verify(userRepository, atMost(2)).save(captor.capture());
+        assertThat(captor.getAllValues()).extracting(AppUser::getUsername)
+                .doesNotContain("user");
     }
-
-    // --- forum category seeding ---
 
     @Test
     void run_whenNoCategoriesExist_seedsCategories() throws Exception {
-        when(userRepository.findByUsername("user")).thenReturn(Optional.of(new AppUser("user", "pass", "USER")));
         when(forumCategoryRepository.count()).thenReturn(0L);
 
         dataInitializer.run(applicationArguments);
@@ -135,7 +153,6 @@ class DataInitializerTest {
 
     @Test
     void run_whenCategoriesExist_doesNotSeedAgain() throws Exception {
-        when(userRepository.findByUsername("user")).thenReturn(Optional.of(new AppUser("user", "pass", "USER")));
         when(forumCategoryRepository.count()).thenReturn(3L);
 
         dataInitializer.run(applicationArguments);

--- a/backend/src/test/java/techchamps/io/controller/AuthControllerTest.java
+++ b/backend/src/test/java/techchamps/io/controller/AuthControllerTest.java
@@ -6,6 +6,7 @@ import techchamps.io.config.SecurityConfig;
 import techchamps.io.dto.request.LoginRequest;
 import techchamps.io.dto.request.RegisterRequest;
 import techchamps.io.model.AppUser;
+import techchamps.io.model.Role;
 import techchamps.io.repository.AppUserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
+import java.util.Optional;
 
 import org.mockito.ArgumentCaptor;
 
@@ -39,7 +41,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import({SecurityConfig.class, CorsConfig.class, AuthControllerTest.TestSecurityConfig.class})
 class AuthControllerTest {
 
-    /** Provides a no-op UserDetailsService so SecurityConfig wires up without the real DB service. */
     @TestConfiguration
     static class TestSecurityConfig {
         @Bean
@@ -65,14 +66,18 @@ class AuthControllerTest {
     @MockBean
     private PasswordEncoder passwordEncoder;
 
-    // --- happy path: valid credentials ---
+    private void mockSuccessfulAuth(String username) {
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(username, null, Collections.emptyList());
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(auth);
+        when(appUserRepository.findByUsername(username))
+                .thenReturn(Optional.of(new AppUser(username, "encoded", Role.USER)));
+    }
 
     @Test
     void login_withValidCredentials_returns200AndSuccess() throws Exception {
-        UsernamePasswordAuthenticationToken auth =
-                new UsernamePasswordAuthenticationToken("user", null, Collections.emptyList());
-        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-                .thenReturn(auth);
+        mockSuccessfulAuth("user");
 
         LoginRequest request = new LoginRequest("user", "user1234");
 
@@ -82,10 +87,9 @@ class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("Login successful"))
-                .andExpect(jsonPath("$.username").value("user"));
+                .andExpect(jsonPath("$.username").value("user"))
+                .andExpect(jsonPath("$.role").value("USER"));
     }
-
-    // --- edge case: wrong password ---
 
     @Test
     void login_withInvalidCredentials_returns401AndFailure() throws Exception {
@@ -103,8 +107,6 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.username").doesNotExist());
     }
 
-    // --- edge case: unknown username ---
-
     @Test
     void login_withUnknownUsername_returns401() throws Exception {
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
@@ -119,8 +121,6 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.success").value(false));
     }
 
-    // --- edge case: empty body still reaches the controller ---
-
     @Test
     void login_withEmptyCredentials_callsAuthManagerAndReturns401() throws Exception {
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
@@ -134,14 +134,9 @@ class AuthControllerTest {
                 .andExpect(status().isUnauthorized());
     }
 
-    // --- verify response body content type ---
-
     @Test
     void login_withValidCredentials_returnsJsonContentType() throws Exception {
-        UsernamePasswordAuthenticationToken auth =
-                new UsernamePasswordAuthenticationToken("user", null, Collections.emptyList());
-        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-                .thenReturn(auth);
+        mockSuccessfulAuth("user");
 
         LoginRequest request = new LoginRequest("user", "user1234");
 
@@ -153,7 +148,23 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.username").value("user"));
     }
 
-    // --- register: happy path ---
+    @Test
+    void login_withValidCredentials_returnsRoleInResponse() throws Exception {
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken("admin", null, Collections.emptyList());
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(auth);
+        when(appUserRepository.findByUsername("admin"))
+                .thenReturn(Optional.of(new AppUser("admin", "encoded", Role.ADMIN)));
+
+        LoginRequest request = new LoginRequest("admin", "admin1234");
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("ADMIN"));
+    }
 
     @Test
     void register_withValidRequest_returns200AndSuccess() throws Exception {
@@ -161,7 +172,7 @@ class AuthControllerTest {
         when(appUserRepository.existsByUsername(anyString())).thenReturn(false);
         when(passwordEncoder.encode(anyString())).thenReturn("hashedPassword");
 
-        AppUser savedUser = new AppUser("new@example.com", "newuser", "hashedPassword", "USER");
+        AppUser savedUser = new AppUser("new@example.com", "newuser", "hashedPassword", Role.USER);
         when(appUserRepository.save(any(AppUser.class))).thenReturn(savedUser);
 
         RegisterRequest request = new RegisterRequest("new@example.com", "newuser", "password123");
@@ -176,16 +187,13 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.username").value("newuser"));
     }
 
-    // --- register: verify id is returned in response ---
-
     @Test
     void register_returnsIdFromSavedUser() throws Exception {
         when(appUserRepository.existsByEmail(anyString())).thenReturn(false);
         when(appUserRepository.existsByUsername(anyString())).thenReturn(false);
         when(passwordEncoder.encode(anyString())).thenReturn("hashedPassword");
 
-        AppUser savedUser = new AppUser("new@example.com", "newuser", "hashedPassword", "USER");
-        // Simulate that the repository sets an ID on save
+        AppUser savedUser = new AppUser("new@example.com", "newuser", "hashedPassword", Role.USER);
         java.lang.reflect.Field idField = AppUser.class.getDeclaredField("id");
         idField.setAccessible(true);
         idField.set(savedUser, 42L);
@@ -200,8 +208,6 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.id").value(42));
     }
 
-    // --- register: duplicate email ---
-
     @Test
     void register_withDuplicateEmail_returns409() throws Exception {
         when(appUserRepository.existsByEmail("taken@example.com")).thenReturn(true);
@@ -215,8 +221,6 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.message").value("Email address is already in use"));
     }
-
-    // --- register: duplicate username ---
 
     @Test
     void register_withDuplicateUsername_returns409() throws Exception {
@@ -233,8 +237,6 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.message").value("Username is already in use"));
     }
 
-    // --- register: invalid email format ---
-
     @Test
     void register_withInvalidEmail_returns400() throws Exception {
         RegisterRequest request = new RegisterRequest("not-an-email", "newuser", "password123");
@@ -244,8 +246,6 @@ class AuthControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
     }
-
-    // --- register: password too short ---
 
     @Test
     void register_withShortPassword_returns400() throws Exception {
@@ -257,14 +257,9 @@ class AuthControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
-    // --- login: verify password is passed through to authenticationManager ---
-
     @Test
     void login_verifiesPasswordPassedToAuthManager() throws Exception {
-        UsernamePasswordAuthenticationToken auth =
-                new UsernamePasswordAuthenticationToken("user", null, Collections.emptyList());
-        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
-                .thenReturn(auth);
+        mockSuccessfulAuth("user");
 
         LoginRequest request = new LoginRequest("user", "secretpass");
 
@@ -278,8 +273,6 @@ class AuthControllerTest {
         verify(authenticationManager).authenticate(captor.capture());
         assertThat(captor.getValue().getCredentials()).isEqualTo("secretpass");
     }
-
-    // --- register: blank username ---
 
     @Test
     void register_withBlankUsername_returns400() throws Exception {

--- a/backend/src/test/java/techchamps/io/controller/ForumControllerTest.java
+++ b/backend/src/test/java/techchamps/io/controller/ForumControllerTest.java
@@ -841,4 +841,97 @@ class ForumControllerTest {
                 .andExpect(jsonPath("$[1].description").value("Technology"))
                 .andExpect(jsonPath("$[1].icon").value("laptop"));
     }
+    // ============================================================
+    // POST /api/forum/threads/{id}/close — close/reopen thread
+    // ============================================================
+
+    @Test
+    @WithMockUser(username = "moderator")
+    void closeThread_asModerator_returns200() throws Exception {
+        ForumThreadResponse closed = new ForumThreadResponse();
+        closed.setId(1L);
+        closed.setTitle("Test Thread");
+        closed.setIsClosed(true);
+        when(forumService.setThreadClosed(1L, "moderator", true)).thenReturn(closed);
+
+        mockMvc.perform(post("/api/forum/threads/1/close")
+                        .param("closed", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.closed").value(true));
+
+        verify(forumService).setThreadClosed(1L, "moderator", true);
+    }
+
+    @Test
+    @WithMockUser(username = "user")
+    void closeThread_asRegularUser_returns403() throws Exception {
+        doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Requires MODERATOR or ADMIN role"))
+                .when(forumService).setThreadClosed(1L, "user", true);
+
+        mockMvc.perform(post("/api/forum/threads/1/close")
+                        .param("closed", "true"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void closeThread_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(post("/api/forum/threads/1/close"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "moderator")
+    void reopenThread_asModerator_returns200() throws Exception {
+        ForumThreadResponse reopened = new ForumThreadResponse();
+        reopened.setId(1L);
+        reopened.setIsClosed(false);
+        when(forumService.setThreadClosed(1L, "moderator", false)).thenReturn(reopened);
+
+        mockMvc.perform(post("/api/forum/threads/1/close")
+                        .param("closed", "false"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.closed").value(false));
+    }
+
+    // ============================================================
+    // DELETE /api/forum/replies/{id} — delete reply
+    // ============================================================
+
+    @Test
+    @WithMockUser(username = "moderator")
+    void deleteReply_asModerator_returns204() throws Exception {
+        doNothing().when(forumService).deleteReply(5L, "moderator");
+
+        mockMvc.perform(delete("/api/forum/replies/5"))
+                .andExpect(status().isNoContent());
+
+        verify(forumService).deleteReply(5L, "moderator");
+    }
+
+    @Test
+    @WithMockUser(username = "user")
+    void deleteReply_asRegularUser_returns403() throws Exception {
+        doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Requires MODERATOR or ADMIN role"))
+                .when(forumService).deleteReply(5L, "user");
+
+        mockMvc.perform(delete("/api/forum/replies/5"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deleteReply_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(delete("/api/forum/replies/5"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "moderator")
+    void deleteReply_notFound_returns404() throws Exception {
+        doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Reply not found"))
+                .when(forumService).deleteReply(999L, "moderator");
+
+        mockMvc.perform(delete("/api/forum/replies/999"))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/backend/src/test/java/techchamps/io/controller/UserControllerTest.java
+++ b/backend/src/test/java/techchamps/io/controller/UserControllerTest.java
@@ -1,0 +1,80 @@
+package techchamps.io.controller;
+
+import techchamps.io.config.CorsConfig;
+import techchamps.io.config.SecurityConfig;
+import techchamps.io.dto.response.UserSummaryResponse;
+import techchamps.io.service.ForumService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+@Import({SecurityConfig.class, CorsConfig.class, UserControllerTest.TestSecurityConfig.class})
+class UserControllerTest {
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+        @Bean
+        UserDetailsService userDetailsService() {
+            return username -> {
+                throw new UsernameNotFoundException("No users in test context");
+            };
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ForumService forumService;
+
+    @Test
+    @WithMockUser(username = "admin")
+    void listUsers_asAdmin_returns200WithUserList() throws Exception {
+        List<UserSummaryResponse> users = List.of(
+                new UserSummaryResponse(1L, "user", "user@example.com", "USER"),
+                new UserSummaryResponse(2L, "moderator", "moderator@example.com", "MODERATOR"),
+                new UserSummaryResponse(3L, "admin", "admin@example.com", "ADMIN")
+        );
+        when(forumService.listUsers("admin")).thenReturn(users);
+
+        mockMvc.perform(get("/api/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(3))
+                .andExpect(jsonPath("$[0].username").value("user"))
+                .andExpect(jsonPath("$[0].role").value("USER"))
+                .andExpect(jsonPath("$[2].role").value("ADMIN"));
+    }
+
+    @Test
+    @WithMockUser(username = "user")
+    void listUsers_asRegularUser_returns403() throws Exception {
+        doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Requires ADMIN role"))
+                .when(forumService).listUsers("user");
+
+        mockMvc.perform(get("/api/users"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void listUsers_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(get("/api/users"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/backend/src/test/java/techchamps/io/model/AppUserTest.java
+++ b/backend/src/test/java/techchamps/io/model/AppUserTest.java
@@ -6,40 +6,33 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class AppUserTest {
 
-    // --- getRole() (kills EMPTY_RETURN on line 33) ---
-
     @Test
     void getRole_returnsCorrectRole() {
-        AppUser user = new AppUser("alice", "secret", "USER");
-        assertThat(user.getRole()).isEqualTo("USER");
+        AppUser user = new AppUser("alice", "secret", Role.USER);
+        assertThat(user.getRole()).isEqualTo(Role.USER);
     }
 
     @Test
     void getRole_returnsAdminRole() {
-        AppUser user = new AppUser("admin", "secret", "ADMIN");
-        assertThat(user.getRole()).isEqualTo("ADMIN");
+        AppUser user = new AppUser("admin", "secret", Role.ADMIN);
+        assertThat(user.getRole()).isEqualTo(Role.ADMIN);
     }
 
     @Test
-    void getRole_isNotEmpty() {
-        AppUser user = new AppUser("bob", "pass", "USER");
-        assertThat(user.getRole()).isNotEmpty();
+    void getRole_isNotNull() {
+        AppUser user = new AppUser("bob", "pass", Role.USER);
+        assertThat(user.getRole()).isNotNull();
     }
-
-    // --- getId() (kills LONG_RETURN 0L on line 30) ---
 
     @Test
     void getId_returnsNullBeforePersistence() {
-        AppUser user = new AppUser("charlie", "pass", "USER");
-        // Before JPA assigns an id, getId() returns null — not 0L
+        AppUser user = new AppUser("charlie", "pass", Role.USER);
         assertThat(user.getId()).isNull();
     }
 
-    // --- getUsername / getPassword sanity (supports DatabaseUserDetailsService coverage) ---
-
     @Test
     void getUsername_returnsCorrectUsername() {
-        AppUser user = new AppUser("diana", "pass", "USER");
+        AppUser user = new AppUser("diana", "pass", Role.USER);
         assertThat(user.getUsername()).isEqualTo("diana");
     }
 }

--- a/backend/src/test/java/techchamps/io/model/ForumVoteTest.java
+++ b/backend/src/test/java/techchamps/io/model/ForumVoteTest.java
@@ -8,7 +8,7 @@ class ForumVoteTest {
 
     @Test
     void constructorAndGetters_returnCorrectValues() {
-        AppUser voter = new AppUser("voter@test.com", "voter", "pass", "USER");
+        AppUser voter = new AppUser("voter@test.com", "voter", "pass", Role.USER);
         ForumVote vote = new ForumVote(voter, 42L, "thread", 1);
 
         assertThat(vote.getVoter()).isSameAs(voter);
@@ -26,8 +26,8 @@ class ForumVoteTest {
 
     @Test
     void setters_overrideConstructorValues() {
-        AppUser voter1 = new AppUser("v1@test.com", "v1", "pass", "USER");
-        AppUser voter2 = new AppUser("v2@test.com", "v2", "pass", "USER");
+        AppUser voter1 = new AppUser("v1@test.com", "v1", "pass", Role.USER);
+        AppUser voter2 = new AppUser("v2@test.com", "v2", "pass", Role.USER);
         ForumVote vote = new ForumVote(voter1, 1L, "thread", 1);
 
         vote.setVoter(voter2);

--- a/backend/src/test/java/techchamps/io/model/UserProfileTest.java
+++ b/backend/src/test/java/techchamps/io/model/UserProfileTest.java
@@ -21,7 +21,7 @@ class UserProfileTest {
 
     @Test
     void constructorWithUser_setsUser() {
-        AppUser user = new AppUser("test@example.com", "testuser", "password", "USER");
+        AppUser user = new AppUser("test@example.com", "testuser", "password", Role.USER);
         UserProfile profile = new UserProfile(user);
 
         assertThat(profile.getUser()).isEqualTo(user);
@@ -31,7 +31,7 @@ class UserProfileTest {
     @Test
     void settersAndGetters_workCorrectly() {
         UserProfile profile = new UserProfile();
-        AppUser user = new AppUser("test@example.com", "testuser", "password", "USER");
+        AppUser user = new AppUser("test@example.com", "testuser", "password", Role.USER);
 
         profile.setUser(user);
         profile.setDisplayName("Test User");

--- a/backend/src/test/java/techchamps/io/security/DatabaseUserDetailsServiceTest.java
+++ b/backend/src/test/java/techchamps/io/security/DatabaseUserDetailsServiceTest.java
@@ -1,6 +1,7 @@
 package techchamps.io.security;
 
 import techchamps.io.model.AppUser;
+import techchamps.io.model.Role;
 import techchamps.io.repository.AppUserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,11 +26,9 @@ class DatabaseUserDetailsServiceTest {
     @InjectMocks
     private DatabaseUserDetailsService service;
 
-    // --- happy path: user found ---
-
     @Test
     void loadUserByUsername_withExistingUser_returnsUserDetails() {
-        AppUser user = new AppUser("alice", "encodedPass", "USER");
+        AppUser user = new AppUser("alice", "encodedPass", Role.USER);
         when(userRepository.findByUsername("alice")).thenReturn(Optional.of(user));
 
         UserDetails details = service.loadUserByUsername("alice");
@@ -38,11 +37,9 @@ class DatabaseUserDetailsServiceTest {
         assertThat(details.getPassword()).isEqualTo("encodedPass");
     }
 
-    // --- happy path: role mapped with ROLE_ prefix ---
-
     @Test
     void loadUserByUsername_mapsRoleWithPrefix() {
-        AppUser user = new AppUser("alice", "encodedPass", "USER");
+        AppUser user = new AppUser("alice", "encodedPass", Role.USER);
         when(userRepository.findByUsername("alice")).thenReturn(Optional.of(user));
 
         UserDetails details = service.loadUserByUsername("alice");
@@ -54,7 +51,7 @@ class DatabaseUserDetailsServiceTest {
 
     @Test
     void loadUserByUsername_adminRole_mapsCorrectly() {
-        AppUser admin = new AppUser("admin", "encodedPass", "ADMIN");
+        AppUser admin = new AppUser("admin", "encodedPass", Role.ADMIN);
         when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
 
         UserDetails details = service.loadUserByUsername("admin");
@@ -63,8 +60,6 @@ class DatabaseUserDetailsServiceTest {
                 .extracting(a -> a.getAuthority())
                 .containsExactly("ROLE_ADMIN");
     }
-
-    // --- expected exception: user not found ---
 
     @Test
     void loadUserByUsername_withUnknownUser_throwsUsernameNotFoundException() {
@@ -75,11 +70,9 @@ class DatabaseUserDetailsServiceTest {
                 .hasMessageContaining("nobody");
     }
 
-    // --- edge case: single authority only ---
-
     @Test
     void loadUserByUsername_returnsExactlyOneAuthority() {
-        AppUser user = new AppUser("bob", "pass", "USER");
+        AppUser user = new AppUser("bob", "pass", Role.USER);
         when(userRepository.findByUsername("bob")).thenReturn(Optional.of(user));
 
         UserDetails details = service.loadUserByUsername("bob");

--- a/backend/src/test/java/techchamps/io/service/ForumServiceTest.java
+++ b/backend/src/test/java/techchamps/io/service/ForumServiceTest.java
@@ -830,7 +830,7 @@ class ForumServiceTest {
     @Test
     void deleteThread_asAdmin_deletesSuccessfully() {
         AppUser admin = createUser("admin");
-        admin.setRole("ADMIN");
+        admin.setRole(Role.ADMIN);
         ForumThread thread = createThread(1L, "Title", "Desc");
         // Thread owned by testuser, not admin
         when(threadRepository.findById(1L)).thenReturn(Optional.of(thread));
@@ -1109,7 +1109,7 @@ class ForumServiceTest {
     @Test
     void deleteThread_asOwner_notAdmin_succeeds() {
         AppUser owner = createUser("threadauthor");
-        owner.setRole("USER");
+        owner.setRole(Role.USER);
         ForumThread thread = createThread(1L, "Title", "Desc");
         thread.setAuthor(owner);
         when(threadRepository.findById(1L)).thenReturn(Optional.of(thread));
@@ -1123,7 +1123,7 @@ class ForumServiceTest {
     @Test
     void deleteThread_asAdmin_notOwner_succeeds() {
         AppUser admin = createUser("adminuser");
-        admin.setRole("ADMIN");
+        admin.setRole(Role.ADMIN);
         AppUser threadOwner = createUser("owner");
         ForumThread thread = createThread(1L, "Title", "Desc");
         thread.setAuthor(threadOwner);
@@ -1138,7 +1138,7 @@ class ForumServiceTest {
     @Test
     void deleteThread_nonOwnerWithUserRole_throwsForbidden() {
         AppUser other = createUser("other");
-        other.setRole("USER");
+        other.setRole(Role.USER);
         AppUser threadOwner = createUser("owner");
         ForumThread thread = createThread(1L, "Title", "Desc");
         thread.setAuthor(threadOwner);
@@ -1427,7 +1427,7 @@ class ForumServiceTest {
     // ============================================================
 
     private AppUser createUser(String username) {
-        AppUser user = new AppUser("user@example.com", username, "encoded", "USER");
+        AppUser user = new AppUser("user@example.com", username, "encoded", Role.USER);
         return user;
     }
 
@@ -1458,4 +1458,220 @@ class ForumServiceTest {
         reply.setAuthor(createUser("testuser"));
         return reply;
     }
+
+    // ============================================================
+    // setThreadClosed — moderator/admin close/reopen thread
+    // ============================================================
+
+    @Test
+    void setThreadClosed_asModerator_closesThread() {
+        AppUser mod = createUser("mod");
+        mod.setRole(Role.MODERATOR);
+        ForumThread thread = createThread(1L, "Title", "Desc");
+        when(userRepository.findByUsername("mod")).thenReturn(Optional.of(mod));
+        when(threadRepository.findById(1L)).thenReturn(Optional.of(thread));
+        when(threadRepository.save(any(ForumThread.class))).thenReturn(thread);
+        when(threadRepository.countRepliesByThreadId(1L)).thenReturn(0L);
+
+        ForumThreadResponse result = forumService.setThreadClosed(1L, "mod", true);
+
+        assertThat(result).isNotNull();
+        verify(threadRepository).save(thread);
+    }
+
+    @Test
+    void setThreadClosed_asAdmin_closesThread() {
+        AppUser admin = createUser("admin");
+        admin.setRole(Role.ADMIN);
+        ForumThread thread = createThread(1L, "Title", "Desc");
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
+        when(threadRepository.findById(1L)).thenReturn(Optional.of(thread));
+        when(threadRepository.save(any(ForumThread.class))).thenReturn(thread);
+        when(threadRepository.countRepliesByThreadId(1L)).thenReturn(0L);
+
+        ForumThreadResponse result = forumService.setThreadClosed(1L, "admin", true);
+
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    void setThreadClosed_asRegularUser_throwsForbidden() {
+        AppUser user = createUser("user");
+        when(userRepository.findByUsername("user")).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> forumService.setThreadClosed(1L, "user", true))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting("status.value")
+                .isEqualTo(403);
+    }
+
+    @Test
+    void setThreadClosed_userNotFound_throws404() {
+        when(userRepository.findByUsername("ghost")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> forumService.setThreadClosed(1L, "ghost", true))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("User not found");
+    }
+
+    @Test
+    void setThreadClosed_threadNotFound_throws404() {
+        AppUser mod = createUser("mod");
+        mod.setRole(Role.MODERATOR);
+        when(userRepository.findByUsername("mod")).thenReturn(Optional.of(mod));
+        when(threadRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> forumService.setThreadClosed(999L, "mod", true))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Thread not found");
+    }
+
+    // ============================================================
+    // deleteReply — moderator/admin delete reply
+    // ============================================================
+
+    @Test
+    void deleteReply_asModerator_deletesReply() {
+        AppUser mod = createUser("mod");
+        mod.setRole(Role.MODERATOR);
+        ForumThread thread = createThread(1L, "Title", "Desc");
+        ForumReply reply = createReply(10L, thread, null, "content", 0);
+        when(userRepository.findByUsername("mod")).thenReturn(Optional.of(mod));
+        when(replyRepository.findById(10L)).thenReturn(Optional.of(reply));
+
+        forumService.deleteReply(10L, "mod");
+
+        verify(replyRepository).delete(reply);
+    }
+
+    @Test
+    void deleteReply_asAdmin_deletesReply() {
+        AppUser admin = createUser("admin");
+        admin.setRole(Role.ADMIN);
+        ForumThread thread = createThread(1L, "Title", "Desc");
+        ForumReply reply = createReply(10L, thread, null, "content", 0);
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
+        when(replyRepository.findById(10L)).thenReturn(Optional.of(reply));
+
+        forumService.deleteReply(10L, "admin");
+
+        verify(replyRepository).delete(reply);
+    }
+
+    @Test
+    void deleteReply_asRegularUser_throwsForbidden() {
+        AppUser user = createUser("user");
+        when(userRepository.findByUsername("user")).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> forumService.deleteReply(10L, "user"))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting("status.value")
+                .isEqualTo(403);
+    }
+
+    @Test
+    void deleteReply_userNotFound_throws404() {
+        when(userRepository.findByUsername("ghost")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> forumService.deleteReply(10L, "ghost"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("User not found");
+    }
+
+    @Test
+    void deleteReply_replyNotFound_throws404() {
+        AppUser mod = createUser("mod");
+        mod.setRole(Role.MODERATOR);
+        when(userRepository.findByUsername("mod")).thenReturn(Optional.of(mod));
+        when(replyRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> forumService.deleteReply(999L, "mod"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Reply not found");
+    }
+
+    // ============================================================
+    // listUsers — admin list all users
+    // ============================================================
+
+    @Test
+    void listUsers_asAdmin_returnsAllUsers() {
+        AppUser admin = createUser("admin");
+        admin.setRole(Role.ADMIN);
+        AppUser user1 = createUser("alice");
+        AppUser user2 = createUser("bob");
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
+        when(userRepository.findAll()).thenReturn(List.of(admin, user1, user2));
+
+        List<UserSummaryResponse> result = forumService.listUsers("admin");
+
+        assertThat(result).hasSize(3);
+        assertThat(result).extracting(UserSummaryResponse::getUsername)
+                .contains("admin", "alice", "bob");
+    }
+
+    @Test
+    void listUsers_roleNameInResponse() {
+        AppUser admin = createUser("admin");
+        admin.setRole(Role.ADMIN);
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
+        when(userRepository.findAll()).thenReturn(List.of(admin));
+
+        List<UserSummaryResponse> result = forumService.listUsers("admin");
+
+        assertThat(result.get(0).getRole()).isEqualTo("ADMIN");
+    }
+
+    @Test
+    void listUsers_asRegularUser_throwsForbidden() {
+        AppUser user = createUser("user");
+        when(userRepository.findByUsername("user")).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> forumService.listUsers("user"))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting("status.value")
+                .isEqualTo(403);
+    }
+
+    @Test
+    void listUsers_asModerator_throwsForbidden() {
+        AppUser mod = createUser("mod");
+        mod.setRole(Role.MODERATOR);
+        when(userRepository.findByUsername("mod")).thenReturn(Optional.of(mod));
+
+        assertThatThrownBy(() -> forumService.listUsers("mod"))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting("status.value")
+                .isEqualTo(403);
+    }
+
+    @Test
+    void listUsers_userNotFound_throws404() {
+        when(userRepository.findByUsername("ghost")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> forumService.listUsers("ghost"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("User not found");
+    }
+
+    // ============================================================
+    // createReply — closed thread rejection
+    // ============================================================
+
+    @Test
+    void createReply_closedThread_throwsForbidden() {
+        AppUser author = createUser("author");
+        ForumThread thread = createThread(1L, "Title", "Desc");
+        thread.setIsClosed(true);
+        when(userRepository.findByUsername("author")).thenReturn(Optional.of(author));
+        when(threadRepository.findById(1L)).thenReturn(Optional.of(thread));
+
+        CreateReplyRequest request = new CreateReplyRequest("content", null);
+
+        assertThatThrownBy(() -> forumService.createReply(1L, "author", request))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting("status.value")
+                .isEqualTo(403);
+    }
+
 }

--- a/backend/src/test/java/techchamps/io/service/ProfileServiceTest.java
+++ b/backend/src/test/java/techchamps/io/service/ProfileServiceTest.java
@@ -4,6 +4,7 @@ import techchamps.io.dto.request.UpdateProfileRequest;
 import techchamps.io.dto.response.AvatarUploadResponse;
 import techchamps.io.dto.response.ProfileResponse;
 import techchamps.io.model.AppUser;
+import techchamps.io.model.Role;
 import techchamps.io.repository.AppUserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -200,7 +201,7 @@ class ProfileServiceTest {
     // --- helper ---
 
     private AppUser createSampleUser() {
-        AppUser user = new AppUser("user@example.com", "user", "encodedPassword", "USER");
+        AppUser user = new AppUser("user@example.com", "user", "encodedPassword", Role.USER);
         user.setDisplayName("Demo User");
         user.setBio("A short bio");
         user.setLocation("Amsterdam");

--- a/frontend/app/forum/threads/[id]/page.tsx
+++ b/frontend/app/forum/threads/[id]/page.tsx
@@ -10,6 +10,8 @@ import {
   getForumThread,
   createForumReply,
   voteOnPost,
+  closeThread,
+  deleteReply,
   type ForumThreadDetailResponse,
   type ForumReplyResponse,
 } from "@/lib/api";
@@ -24,10 +26,14 @@ export default function ThreadDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [replyLoading, setReplyLoading] = useState(false);
+  const [replyError, setReplyError] = useState<string | null>(null);
   const [username, setUsername] = useState<string | null>(null);
+  const [role, setRole] = useState<string | null>(null);
+  const [closeLoading, setCloseLoading] = useState(false);
 
   useEffect(() => {
     setUsername(localStorage.getItem("username"));
+    setRole(localStorage.getItem("role"));
   }, []);
 
   useEffect(() => {
@@ -38,6 +44,8 @@ export default function ThreadDetailPage() {
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
   }, [threadId]);
+
+  const isModerator = role === "MODERATOR" || role === "ADMIN";
 
   async function handleVoteThread(value: number) {
     if (!thread || !username) return;
@@ -58,7 +66,6 @@ export default function ThreadDetailPage() {
     const password = localStorage.getItem("password") ?? "";
     try {
       await voteOnPost(replyId, "reply", value, { username, password });
-      // Reload thread to reflect updated reply score
       const updated = await getForumThread(threadId);
       setThread(updated);
     } catch (err) {
@@ -70,6 +77,7 @@ export default function ThreadDetailPage() {
     if (!username || !thread) return;
     const password = localStorage.getItem("password") ?? "";
     setReplyLoading(true);
+    setReplyError(null);
     try {
       await createForumReply(
         thread.id,
@@ -78,6 +86,8 @@ export default function ThreadDetailPage() {
       );
       const updated = await getForumThread(threadId);
       setThread(updated);
+    } catch (err) {
+      setReplyError((err as Error).message ?? "Failed to post reply");
     } finally {
       setReplyLoading(false);
     }
@@ -97,6 +107,32 @@ export default function ThreadDetailPage() {
     );
     const updated = await getForumThread(threadId);
     setThread(updated);
+  }
+
+  async function handleDeleteReply(replyId: number) {
+    if (!username) return;
+    const password = localStorage.getItem("password") ?? "";
+    try {
+      await deleteReply(replyId, { username, password });
+      const updated = await getForumThread(threadId);
+      setThread(updated);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function handleCloseThread(closed: boolean) {
+    if (!username || !thread) return;
+    const password = localStorage.getItem("password") ?? "";
+    setCloseLoading(true);
+    try {
+      const updated = await closeThread(thread.id, closed, { username, password });
+      setThread((prev) => (prev ? { ...prev, closed: updated.closed } : prev));
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setCloseLoading(false);
+    }
   }
 
   if (loading) {
@@ -127,16 +163,25 @@ export default function ThreadDetailPage() {
       </nav>
 
       <main className="mx-auto max-w-3xl px-4 py-8">
-        {/* Thread header */}
         <div className={card.paddedLg}>
           <div className="flex items-start justify-between gap-4">
             <div className="flex-1">
-              <h1
-                className={typography.pageHeading}
-                data-testid="thread-detail-title"
-              >
-                {thread.title}
-              </h1>
+              <div className="flex items-center gap-2 flex-wrap">
+                <h1
+                  className={typography.pageHeading}
+                  data-testid="thread-detail-title"
+                >
+                  {thread.title}
+                </h1>
+                {thread.closed && (
+                  <span
+                    className="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-700"
+                    data-testid="thread-closed-badge"
+                  >
+                    CLOSED
+                  </span>
+                )}
+              </div>
               <p
                 className={`${typography.helperText} mt-1`}
                 data-testid="thread-detail-author"
@@ -159,17 +204,28 @@ export default function ThreadDetailPage() {
                 Score: {thread.score}
               </p>
             </div>
-            <VoteButtons
-              score={thread.score}
-              postId={thread.id}
-              postType="thread"
-              onVote={handleVoteThread}
-              disabled={!username}
-            />
+            <div className="flex flex-col items-end gap-2">
+              <VoteButtons
+                score={thread.score}
+                postId={thread.id}
+                postType="thread"
+                onVote={handleVoteThread}
+                disabled={!username}
+              />
+              {isModerator && (
+                <button
+                  onClick={() => handleCloseThread(!thread.closed)}
+                  disabled={closeLoading}
+                  className="text-sm px-3 py-1 rounded border border-gray-300 hover:bg-gray-100 disabled:opacity-50"
+                  data-testid="close-thread-button"
+                >
+                  {thread.closed ? "Reopen Thread" : "Close Thread"}
+                </button>
+              )}
+            </div>
           </div>
         </div>
 
-        {/* Replies section */}
         <div className="mt-8" data-testid="replies-section">
           <h2 className={typography.sectionHeading}>
             {thread.replies?.length ?? 0} Replies
@@ -182,14 +238,20 @@ export default function ThreadDetailPage() {
               depth={0}
               onVote={handleVoteReply}
               onReply={handleNestedReply}
+              onDelete={isModerator ? handleDeleteReply : undefined}
               threadId={thread.id}
               isLoggedIn={Boolean(username)}
             />
           ))}
 
-          {username && (
+          {username && !thread.closed && (
             <div className="mt-6">
               <h3 className={typography.sectionHeading}>Add a Reply</h3>
+              {replyError && (
+                <div className={`${alert.error} mt-2`} data-testid="reply-thread-error">
+                  {replyError}
+                </div>
+              )}
               <div className="mt-2">
                 <ReplyForm
                   onSubmit={handleDirectReply}
@@ -197,6 +259,12 @@ export default function ThreadDetailPage() {
                   depth={0}
                 />
               </div>
+            </div>
+          )}
+
+          {username && thread.closed && (
+            <div className={`${alert.error} mt-6`} data-testid="thread-closed-message">
+              This thread is closed. No new replies can be posted.
             </div>
           )}
         </div>

--- a/frontend/components/LoginForm.test.tsx
+++ b/frontend/components/LoginForm.test.tsx
@@ -354,4 +354,35 @@ describe("LoginForm", () => {
     await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/dashboard"));
     expect(screen.queryByTestId("login-error")).not.toBeInTheDocument();
   });
+
+  it("stores the role in localStorage on successful login", async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValueOnce({ username: "moderator", role: "MODERATOR" }),
+    });
+
+    render(<LoginForm />);
+    fillAndSubmit("moderator", "moderator1234");
+
+    await waitFor(() => {
+      expect(localStorage.getItem("role")).toBe("MODERATOR");
+    });
+  });
+
+  it("does not store role in localStorage when role is absent in response", async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockResolvedValueOnce({ username: "user" }),
+    });
+
+    render(<LoginForm />);
+    fillAndSubmit("user", "user1234");
+
+    await waitFor(() => {
+      expect(localStorage.getItem("username")).toBe("user");
+    });
+    expect(localStorage.getItem("role")).toBeNull();
+  });
 });

--- a/frontend/components/LoginForm.tsx
+++ b/frontend/components/LoginForm.tsx
@@ -28,6 +28,9 @@ export default function LoginForm() {
         const data = await response.json();
         // Store the username from the response (server-confirmed)
         if (data.username) {
+          if (data.role) {
+            localStorage.setItem("role", data.role);
+          }
           localStorage.setItem("username", data.username);
         }
         // Store password for HTTP Basic auth in subsequent requests

--- a/frontend/components/LogoutButton.test.tsx
+++ b/frontend/components/LogoutButton.test.tsx
@@ -50,4 +50,11 @@ describe("LogoutButton", () => {
     ).not.toThrow();
     expect(mockPush).toHaveBeenCalledWith("/");
   });
+
+  it("removes role from localStorage on click", () => {
+    localStorage.setItem("role", "MODERATOR");
+    render(<LogoutButton />);
+    fireEvent.click(screen.getByRole("button", { name: /uitloggen/i }));
+    expect(localStorage.getItem("role")).toBeNull();
+  });
 });

--- a/frontend/components/LogoutButton.tsx
+++ b/frontend/components/LogoutButton.tsx
@@ -8,6 +8,7 @@ export default function LogoutButton() {
 
   function handleLogout() {
     localStorage.removeItem("username");
+    localStorage.removeItem("role");
     router.push("/");
   }
 

--- a/frontend/components/ReplyItem.test.tsx
+++ b/frontend/components/ReplyItem.test.tsx
@@ -235,4 +235,23 @@ describe("ReplyItem", () => {
     fireEvent.click(screen.getByTestId("downvote-button"));
     expect(onVote).toHaveBeenCalledWith(1, -1);
   });
+
+  it("does not show delete button when onDelete is not provided", () => {
+    render(<ReplyItem {...defaultProps} />);
+    expect(screen.queryByTestId("delete-reply-1")).not.toBeInTheDocument();
+  });
+
+  it("shows delete button when onDelete is provided", () => {
+    const onDelete = jest.fn().mockResolvedValue(undefined);
+    render(<ReplyItem {...defaultProps} onDelete={onDelete} />);
+    expect(screen.getByTestId("delete-reply-1")).toBeInTheDocument();
+  });
+
+  it("calls onDelete with reply id when delete button clicked", async () => {
+    const onDelete = jest.fn().mockResolvedValue(undefined);
+    render(<ReplyItem {...defaultProps} onDelete={onDelete} />);
+
+    fireEvent.click(screen.getByTestId("delete-reply-1"));
+    await waitFor(() => expect(onDelete).toHaveBeenCalledWith(1));
+  });
 });

--- a/frontend/components/ReplyItem.tsx
+++ b/frontend/components/ReplyItem.tsx
@@ -12,6 +12,7 @@ interface ReplyItemProps {
   depth: number;
   onVote: (replyId: number, value: number) => void;
   onReply: (threadId: number, content: string, parentReplyId: number) => Promise<void>;
+  onDelete?: (replyId: number) => Promise<void>;
   threadId: number;
   isLoggedIn: boolean;
 }
@@ -21,14 +22,15 @@ export default function ReplyItem({
   depth,
   onVote,
   onReply,
+  onDelete,
   threadId,
   isLoggedIn,
 }: ReplyItemProps) {
   const [showReplyForm, setShowReplyForm] = useState(false);
   const [replyLoading, setReplyLoading] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
+  const [deleteLoading, setDeleteLoading] = useState(false);
 
-  // CONSTRAINT: score < -5 renders collapsed/gray style
   const isHidden = reply.score < FORUM_CONSTRAINTS.HIDDEN_SCORE_THRESHOLD;
   const canReply = depth < FORUM_CONSTRAINTS.MAX_REPLY_DEPTH - 1;
   const hasChildren = reply.replies && reply.replies.length > 0;
@@ -43,7 +45,16 @@ export default function ReplyItem({
     }
   }
 
-  // Get initials for avatar placeholder from author username
+  async function handleDelete() {
+    if (!onDelete) return;
+    setDeleteLoading(true);
+    try {
+      await onDelete(reply.id);
+    } finally {
+      setDeleteLoading(false);
+    }
+  }
+
   const initials = reply.authorUsername
     ? reply.authorUsername.slice(0, 2).toUpperCase()
     : "?";
@@ -54,7 +65,6 @@ export default function ReplyItem({
       data-testid={`reply-item-${reply.id}`}
     >
       <div className={`flex gap-2 ${depth > 0 ? "pl-4 border-l-2 border-gray-200" : ""}`}>
-        {/* Collapse toggle in left gutter for nested replies */}
         {depth > 0 && hasChildren && (
           <button
             type="button"
@@ -67,10 +77,8 @@ export default function ReplyItem({
         )}
 
         <div className={`flex-1 ${card.padded} ${isHidden ? "opacity-50 grayscale" : ""}`}>
-          {/* Reply header: avatar + username + date + vote badge */}
           <div className="flex items-center justify-between gap-2 mb-2">
             <div className="flex items-center gap-2" data-testid={`reply-author-${reply.id}`}>
-              {/* Avatar placeholder circle */}
               <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-indigo-100 text-xs font-bold text-indigo-600">
                 {initials}
               </div>
@@ -81,17 +89,28 @@ export default function ReplyItem({
               <span className={typography.helperText}>depth {reply.depth}</span>
             </div>
 
-            {/* Vote badge top-right */}
-            <VoteButtons
-              score={reply.score}
-              postId={reply.id}
-              postType="reply"
-              onVote={(value) => onVote(reply.id, value)}
-              disabled={!isLoggedIn}
-            />
+            <div className="flex items-center gap-2">
+              {onDelete && (
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  disabled={deleteLoading}
+                  className="text-xs text-red-600 hover:text-red-500 disabled:opacity-50"
+                  data-testid={`delete-reply-${reply.id}`}
+                >
+                  {deleteLoading ? "Deleting…" : "Delete"}
+                </button>
+              )}
+              <VoteButtons
+                score={reply.score}
+                postId={reply.id}
+                postType="reply"
+                onVote={(value) => onVote(reply.id, value)}
+                disabled={!isLoggedIn}
+              />
+            </div>
           </div>
 
-          {/* Reply body */}
           <p
             className={typography.bodyText}
             data-testid={`reply-content-${reply.id}`}
@@ -122,7 +141,6 @@ export default function ReplyItem({
         </div>
       </div>
 
-      {/* Nested children */}
       {!collapsed && hasChildren && (
         <div className="ml-4">
           {reply.replies!.map((child) => (
@@ -132,6 +150,7 @@ export default function ReplyItem({
               depth={depth + 1}
               onVote={onVote}
               onReply={onReply}
+              onDelete={onDelete}
               threadId={threadId}
               isLoggedIn={isLoggedIn}
             />

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -97,6 +97,7 @@ export interface ForumThreadResponse {
   categoryId: number;
   categoryName: string;
   replyCount: number;
+  closed: boolean;
 }
 
 export interface ForumReplyResponse {
@@ -232,4 +233,46 @@ export async function voteOnPost(
     throw new Error(body.message ?? `Failed to vote: ${response.status}`);
   }
   return response.json() as Promise<VoteResponse>;
+}
+
+export async function closeThread(
+  threadId: number,
+  closed: boolean,
+  credentials: { username: string; password: string }
+): Promise<ForumThreadResponse> {
+  const response = await fetch(
+    `${API_BASE}/api/forum/threads/${threadId}/close?closed=${closed}`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: basicAuth(credentials.username, credentials.password),
+      },
+    }
+  );
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as { message?: string };
+    if (response.status === 403) {
+      throw new Error("You don't have permission to close threads");
+    }
+    throw new Error(body.message ?? `Failed to close thread: ${response.status}`);
+  }
+  return response.json() as Promise<ForumThreadResponse>;
+}
+
+export async function deleteReply(
+  replyId: number,
+  credentials: { username: string; password: string }
+): Promise<void> {
+  const response = await fetch(`${API_BASE}/api/forum/replies/${replyId}`, {
+    method: "DELETE",
+    headers: {
+      Authorization: basicAuth(credentials.username, credentials.password),
+    },
+  });
+  if (!response.ok) {
+    if (response.status === 403) {
+      throw new Error("You don't have permission to delete replies");
+    }
+    throw new Error(`Failed to delete reply: ${response.status}`);
+  }
 }

--- a/playwright-tests/tests/e2e/pages/ThreadDetailPage.ts
+++ b/playwright-tests/tests/e2e/pages/ThreadDetailPage.ts
@@ -160,4 +160,20 @@ export class ThreadDetailPage {
       .getByRole("button", { name: /collapse replies|expand replies/i })
       .first();
   }
+
+  getClosedBadge(): Locator {
+    return this.page.getByTestId("thread-closed-badge");
+  }
+
+  getCloseThreadButton(): Locator {
+    return this.page.getByTestId("close-thread-button");
+  }
+
+  getThreadClosedMessage(): Locator {
+    return this.page.getByTestId("thread-closed-message");
+  }
+
+  getDeleteReplyButton(replyId: number): Locator {
+    return this.page.getByTestId(`delete-reply-${replyId}`);
+  }
 }

--- a/playwright-tests/tests/e2e/rbac.spec.ts
+++ b/playwright-tests/tests/e2e/rbac.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from "@playwright/test";
+import { LoginPage } from "./pages/LoginPage";
+import { ThreadDetailPage } from "./pages/ThreadDetailPage";
+
+const API_BASE = "http://localhost:8080";
+
+const MODERATOR = { username: "moderator", password: "moderator1234" };
+const USER = { username: "user", password: "user1234" };
+
+async function loginAs(page: import("@playwright/test").Page, creds: { username: string; password: string }) {
+  const loginPage = new LoginPage(page);
+  await loginPage.login(creds.username, creds.password);
+  await page.waitForURL(/\/dashboard/, { timeout: 10000 });
+}
+
+async function createThreadViaApi(credentials: { username: string; password: string }): Promise<number> {
+  const basicAuth = Buffer.from(`${credentials.username}:${credentials.password}`).toString("base64");
+  const res = await fetch(`${API_BASE}/api/forum/threads`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Basic ${basicAuth}`,
+    },
+    body: JSON.stringify({
+      title: `RBAC E2E Test Thread ${Date.now()}`,
+      description: "Thread for RBAC E2E testing",
+    }),
+  });
+  if (!res.ok) throw new Error(`Failed to create thread: ${res.status}`);
+  const data = await res.json() as { id: number };
+  return data.id;
+}
+
+async function createReplyViaApi(
+  threadId: number,
+  credentials: { username: string; password: string }
+): Promise<number> {
+  const basicAuth = Buffer.from(`${credentials.username}:${credentials.password}`).toString("base64");
+  const res = await fetch(`${API_BASE}/api/forum/threads/${threadId}/replies`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Basic ${basicAuth}`,
+    },
+    body: JSON.stringify({ content: "E2E test reply content" }),
+  });
+  if (!res.ok) throw new Error(`Failed to create reply: ${res.status}`);
+  const data = await res.json() as { id: number };
+  return data.id;
+}
+
+test.describe("RBAC — Moderator can close threads", () => {
+  let threadId: number;
+
+  test.beforeEach(async () => {
+    threadId = await createThreadViaApi(USER);
+  });
+
+  test("moderator sees Close Thread button on thread detail", async ({ page }) => {
+    await loginAs(page, MODERATOR);
+    const detailPage = new ThreadDetailPage(page);
+    await detailPage.goto(threadId);
+    await detailPage.waitForLoad();
+
+    await expect(detailPage.getCloseThreadButton()).toBeVisible();
+  });
+
+  test("regular user does not see Close Thread button", async ({ page }) => {
+    await loginAs(page, USER);
+    const detailPage = new ThreadDetailPage(page);
+    await detailPage.goto(threadId);
+    await detailPage.waitForLoad();
+
+    await expect(detailPage.getCloseThreadButton()).not.toBeVisible();
+  });
+
+  test("moderator closes thread — CLOSED badge appears and reply form disappears", async ({ page }) => {
+    await loginAs(page, MODERATOR);
+    const detailPage = new ThreadDetailPage(page);
+    await detailPage.goto(threadId);
+    await detailPage.waitForLoad();
+
+    await detailPage.getCloseThreadButton().click();
+
+    await expect(detailPage.getClosedBadge()).toBeVisible();
+    await expect(detailPage.getThreadClosedMessage()).toBeVisible();
+    await expect(detailPage.getReplyForm()).not.toBeVisible();
+  });
+});
+
+test.describe("RBAC — Moderator can delete replies", () => {
+  let threadId: number;
+  let replyId: number;
+
+  test.beforeEach(async () => {
+    threadId = await createThreadViaApi(USER);
+    replyId = await createReplyViaApi(threadId, USER);
+  });
+
+  test("moderator sees delete button on replies", async ({ page }) => {
+    await loginAs(page, MODERATOR);
+    const detailPage = new ThreadDetailPage(page);
+    await detailPage.goto(threadId);
+    await detailPage.waitForLoad();
+
+    await expect(detailPage.getDeleteReplyButton(replyId)).toBeVisible();
+  });
+
+  test("regular user does not see delete button on replies", async ({ page }) => {
+    await loginAs(page, USER);
+    const detailPage = new ThreadDetailPage(page);
+    await detailPage.goto(threadId);
+    await detailPage.waitForLoad();
+
+    await expect(detailPage.getDeleteReplyButton(replyId)).not.toBeVisible();
+  });
+});
+
+test.describe("RBAC — Closed thread shows error for reply attempt", () => {
+  let threadId: number;
+
+  test.beforeEach(async () => {
+    threadId = await createThreadViaApi(USER);
+    // Close the thread via API
+    const basicAuth = Buffer.from(`${MODERATOR.username}:${MODERATOR.password}`).toString("base64");
+    await fetch(`${API_BASE}/api/forum/threads/${threadId}/close?closed=true`, {
+      method: "POST",
+      headers: { "Authorization": `Basic ${basicAuth}` },
+    });
+  });
+
+  test("closed thread shows CLOSED badge", async ({ page }) => {
+    await loginAs(page, USER);
+    const detailPage = new ThreadDetailPage(page);
+    await detailPage.goto(threadId);
+    await detailPage.waitForLoad();
+
+    await expect(detailPage.getClosedBadge()).toBeVisible();
+  });
+
+  test("closed thread shows closed message and no reply form for logged-in user", async ({ page }) => {
+    await loginAs(page, USER);
+    const detailPage = new ThreadDetailPage(page);
+    await detailPage.goto(threadId);
+    await detailPage.waitForLoad();
+
+    await expect(detailPage.getThreadClosedMessage()).toBeVisible();
+    await expect(detailPage.getReplyForm()).not.toBeVisible();
+  });
+});

--- a/restassured-tests/src/test/java/techchamps/io/RoleBasedAccessControlIT.java
+++ b/restassured-tests/src/test/java/techchamps/io/RoleBasedAccessControlIT.java
@@ -1,0 +1,309 @@
+package techchamps.io;
+
+import techchamps.io.builder.CreateReplyRequestBuilder;
+import techchamps.io.builder.CreateThreadRequestBuilder;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.*;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration tests for role-based access control.
+ *
+ * Tests authorization rules for moderator and admin actions:
+ * - Close/reopen thread (MODERATOR+)
+ * - Delete reply (MODERATOR+)
+ * - List users (ADMIN only)
+ * - Closed thread rejects new replies
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("Role-Based Access Control Integration Tests")
+class RoleBasedAccessControlIT extends BaseIntegrationTest {
+
+    private static final String USER = "user";
+    private static final String USER_PASSWORD = "user1234";
+    private static final String MODERATOR = "moderator";
+    private static final String MODERATOR_PASSWORD = "moderator1234";
+    private static final String ADMIN = "admin";
+    private static final String ADMIN_PASSWORD = "admin1234";
+
+    private Long threadId;
+    private Long replyId;
+
+    @BeforeEach
+    void setup() {
+        // Create a thread as regular user
+        threadId = given()
+            .port(port)
+            .auth().preemptive().basic(USER, USER_PASSWORD)
+            .contentType(ContentType.JSON)
+            .body(new CreateThreadRequestBuilder()
+                .title("RBAC Test Thread")
+                .description("Thread for role-based access control tests")
+                .build())
+        .when()
+            .post("/api/forum/threads")
+        .then()
+            .statusCode(201)
+            .extract().jsonPath().getLong("id");
+
+        // Create a reply on that thread
+        replyId = given()
+            .port(port)
+            .auth().preemptive().basic(USER, USER_PASSWORD)
+            .contentType(ContentType.JSON)
+            .body(new CreateReplyRequestBuilder()
+                .content("A reply for RBAC testing")
+                .build())
+        .when()
+            .post("/api/forum/threads/{id}/replies", threadId)
+        .then()
+            .statusCode(201)
+            .extract().jsonPath().getLong("id");
+    }
+
+    // -------------------------------------------------------------------------
+    // Close thread — authorization
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("POST /api/forum/threads/{id}/close — user cannot close thread (403)")
+    void closeThread_asUser_returns403() {
+        given()
+            .port(port)
+            .auth().preemptive().basic(USER, USER_PASSWORD)
+        .when()
+            .post("/api/forum/threads/{id}/close", threadId)
+        .then()
+            .statusCode(403);
+    }
+
+    @Test
+    @DisplayName("POST /api/forum/threads/{id}/close — moderator can close thread (200)")
+    void closeThread_asModerator_returns200() {
+        given()
+            .port(port)
+            .auth().preemptive().basic(MODERATOR, MODERATOR_PASSWORD)
+            .param("closed", "true")
+        .when()
+            .post("/api/forum/threads/{id}/close", threadId)
+        .then()
+            .statusCode(200)
+            .body("closed", equalTo(true));
+    }
+
+    @Test
+    @DisplayName("POST /api/forum/threads/{id}/close — admin can close thread (200)")
+    void closeThread_asAdmin_returns200() {
+        given()
+            .port(port)
+            .auth().preemptive().basic(ADMIN, ADMIN_PASSWORD)
+            .param("closed", "true")
+        .when()
+            .post("/api/forum/threads/{id}/close", threadId)
+        .then()
+            .statusCode(200)
+            .body("closed", equalTo(true));
+    }
+
+    @Test
+    @DisplayName("POST /api/forum/threads/{id}/close — unauthenticated returns 401")
+    void closeThread_unauthenticated_returns401() {
+        given()
+            .port(port)
+        .when()
+            .post("/api/forum/threads/{id}/close", threadId)
+        .then()
+            .statusCode(401);
+    }
+
+    // -------------------------------------------------------------------------
+    // Closed thread rejects new replies
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Closed thread — replying returns 403")
+    void replyToClosedThread_returns403() {
+        // Close the thread as moderator
+        given()
+            .port(port)
+            .auth().preemptive().basic(MODERATOR, MODERATOR_PASSWORD)
+            .param("closed", "true")
+        .when()
+            .post("/api/forum/threads/{id}/close", threadId)
+        .then()
+            .statusCode(200);
+
+        // Attempt to reply — should be rejected
+        given()
+            .port(port)
+            .auth().preemptive().basic(USER, USER_PASSWORD)
+            .contentType(ContentType.JSON)
+            .body(new CreateReplyRequestBuilder()
+                .content("Trying to reply to closed thread")
+                .build())
+        .when()
+            .post("/api/forum/threads/{id}/replies", threadId)
+        .then()
+            .statusCode(403);
+    }
+
+    @Test
+    @DisplayName("Reopened thread — replying succeeds (201)")
+    void replyToReopenedThread_returns201() {
+        // Close the thread
+        given()
+            .port(port)
+            .auth().preemptive().basic(MODERATOR, MODERATOR_PASSWORD)
+            .param("closed", "true")
+        .when()
+            .post("/api/forum/threads/{id}/close", threadId)
+        .then()
+            .statusCode(200);
+
+        // Reopen the thread
+        given()
+            .port(port)
+            .auth().preemptive().basic(MODERATOR, MODERATOR_PASSWORD)
+            .param("closed", "false")
+        .when()
+            .post("/api/forum/threads/{id}/close", threadId)
+        .then()
+            .statusCode(200)
+            .body("closed", equalTo(false));
+
+        // Reply should succeed now
+        given()
+            .port(port)
+            .auth().preemptive().basic(USER, USER_PASSWORD)
+            .contentType(ContentType.JSON)
+            .body(new CreateReplyRequestBuilder()
+                .content("Reply after reopen")
+                .build())
+        .when()
+            .post("/api/forum/threads/{id}/replies", threadId)
+        .then()
+            .statusCode(201);
+    }
+
+    // -------------------------------------------------------------------------
+    // Delete reply — authorization
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("DELETE /api/forum/replies/{id} — user cannot delete reply (403)")
+    void deleteReply_asUser_returns403() {
+        given()
+            .port(port)
+            .auth().preemptive().basic(USER, USER_PASSWORD)
+        .when()
+            .delete("/api/forum/replies/{id}", replyId)
+        .then()
+            .statusCode(403);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/forum/replies/{id} — moderator can delete reply (204)")
+    void deleteReply_asModerator_returns204() {
+        given()
+            .port(port)
+            .auth().preemptive().basic(MODERATOR, MODERATOR_PASSWORD)
+        .when()
+            .delete("/api/forum/replies/{id}", replyId)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/forum/replies/{id} — admin can delete reply (204)")
+    void deleteReply_asAdmin_returns204() {
+        // Create another reply to delete as admin
+        Long anotherReplyId = given()
+            .port(port)
+            .auth().preemptive().basic(USER, USER_PASSWORD)
+            .contentType(ContentType.JSON)
+            .body(new CreateReplyRequestBuilder()
+                .content("Another reply for admin to delete")
+                .build())
+        .when()
+            .post("/api/forum/threads/{id}/replies", threadId)
+        .then()
+            .statusCode(201)
+            .extract().jsonPath().getLong("id");
+
+        given()
+            .port(port)
+            .auth().preemptive().basic(ADMIN, ADMIN_PASSWORD)
+        .when()
+            .delete("/api/forum/replies/{id}", anotherReplyId)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/forum/replies/{id} — unauthenticated returns 401")
+    void deleteReply_unauthenticated_returns401() {
+        given()
+            .port(port)
+        .when()
+            .delete("/api/forum/replies/{id}", replyId)
+        .then()
+            .statusCode(401);
+    }
+
+    // -------------------------------------------------------------------------
+    // List users — ADMIN only
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("GET /api/users — user cannot list users (403)")
+    void listUsers_asUser_returns403() {
+        given()
+            .port(port)
+            .auth().preemptive().basic(USER, USER_PASSWORD)
+        .when()
+            .get("/api/users")
+        .then()
+            .statusCode(403);
+    }
+
+    @Test
+    @DisplayName("GET /api/users — moderator cannot list users (403)")
+    void listUsers_asModerator_returns403() {
+        given()
+            .port(port)
+            .auth().preemptive().basic(MODERATOR, MODERATOR_PASSWORD)
+        .when()
+            .get("/api/users")
+        .then()
+            .statusCode(403);
+    }
+
+    @Test
+    @DisplayName("GET /api/users — admin can list users (200)")
+    void listUsers_asAdmin_returns200WithUsers() {
+        given()
+            .port(port)
+            .auth().preemptive().basic(ADMIN, ADMIN_PASSWORD)
+        .when()
+            .get("/api/users")
+        .then()
+            .statusCode(200)
+            .body("size()", greaterThanOrEqualTo(3))
+            .body("find { it.username == 'user' }.role", equalTo("USER"))
+            .body("find { it.username == 'moderator' }.role", equalTo("MODERATOR"))
+            .body("find { it.username == 'admin' }.role", equalTo("ADMIN"));
+    }
+
+    @Test
+    @DisplayName("GET /api/users — unauthenticated returns 401")
+    void listUsers_unauthenticated_returns401() {
+        given()
+            .port(port)
+        .when()
+            .get("/api/users")
+        .then()
+            .statusCode(401);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds three-tier RBAC with USER (default), MODERATOR, and ADMIN roles stored in the database
- Moderators can close/reopen threads and delete any reply; Admins can list all users
- Frontend shows role-aware UI: CLOSED badge, Close Thread button (mod+), Delete reply button (mod+)
- Login response now returns the user's role; stored in localStorage for client-side UI decisions

## Changes

### Backend
- `Role.java` enum (USER, MODERATOR, ADMIN) on AppUser entity with `@Enumerated(EnumType.STRING)`
- `ForumThread.isClosed` field to prevent new replies on closed threads
- New endpoints:
  - `POST /api/forum/threads/{id}/close?closed=true` — requires MODERATOR or ADMIN
  - `DELETE /api/forum/replies/{id}` — requires MODERATOR or ADMIN
  - `GET /api/users` — requires ADMIN
- `LoginResponse` now includes `role` field
- `DataInitializer` seeds `user` (USER), `moderator` (MODERATOR), `admin` (ADMIN)
- V004 Liquibase migration: `is_closed`, `parent_reply_id`, `depth` columns

### Frontend
- Thread detail: CLOSED badge, disabled reply form + error message for closed threads
- Close Thread button visible only to MODERATOR/ADMIN
- Delete button on replies visible only to MODERATOR/ADMIN
- `LoginForm` stores `role` in localStorage; `LogoutButton` clears it

### Tests
- All existing tests updated to use `Role` enum (no string role)
- New unit tests: `UserControllerTest`, RBAC scenarios in `ForumServiceTest` and `ForumControllerTest`
- `RoleBasedAccessControlIT` — 14 RestAssured integration tests covering all role boundaries
- `rbac.spec.ts` — Playwright E2E tests for close thread flow and delete reply visibility

## Test plan

- [ ] Backend unit tests: 261 passing
- [ ] RestAssured integration tests: 84 passing (14 new RBAC tests)
- [ ] Frontend Jest tests: 386 passing
- [ ] Playwright E2E: rbac.spec.ts validates moderator UI flows against real backend

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)