### PR TITLE
fix: Use curl/wget fallback for frontend Docker health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     networks:
       - test-project-network
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000"]
+      test: ["CMD-SHELL", "curl -f http://localhost:3000 || (which wget && wget -q -O- http://localhost:3000) || exit 1"]
       interval: 5s
       timeout: 5s
       start_period: 15s


### PR DESCRIPTION
## Summary
Fixed the frontend health check in docker-compose.yml to work properly in CI environments.

## Problem
The test-e2e-docker CI pipeline was failing because:
- Alpine Linux `node:20-alpine` image doesn't include `wget` by default
- Frontend health check was using `wget`, which caused it to fail
- Failed health checks marked the frontend container as unhealthy
- Playwright tests couldn't connect to localhost:3000, resulting in `net::ERR_CONNECTION_REFUSED`

## Solution
Updated the health check to use `curl` (with `wget` as fallback):
- Tries `curl` first (more commonly available in containers)
- Falls back to `wget` if curl isn't available
- Uses shell command to allow the fallback logic

## Testing
✅ Verified locally that docker-compose stack starts with all services healthy
✅ Frontend container reaches "healthy" status within health check timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)