### PR TITLE
Issue #41: Fix frontend and playwright test result parsing in reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,8 +396,8 @@ jobs:
         run: |
           # Copy Playwright test report metadata for the Python script
           mkdir -p playwright-test-results
-          if [ -f "playwright-report/report.json" ]; then
-            cp playwright-report/report.json playwright-test-results/report.json
+          if [ -f "playwright-report/playwright-tests/playwright-report/report.json" ]; then
+            cp playwright-report/playwright-tests/playwright-report/report.json playwright-test-results/report.json
           fi
 
       - name: Generate report

--- a/scripts/generate-report.py
+++ b/scripts/generate-report.py
@@ -45,6 +45,20 @@ def parse_junit_reports():
             except:
                 pass
 
+    # Frontend Jest tests (artifacts downloaded as frontend-test-results/)
+    junit_path = "frontend-test-results"
+    if os.path.exists(junit_path):
+        for file in Path(junit_path).glob("*.xml"):
+            try:
+                tree = ET.parse(file)
+                root = tree.getroot()
+                test_results["frontend"]["passed"] += int(root.get("tests", 0)) - int(root.get("failures", 0)) - int(root.get("skipped", 0))
+                test_results["frontend"]["failed"] += int(root.get("failures", 0))
+                test_results["frontend"]["skipped"] += int(root.get("skipped", 0))
+                test_results["frontend"]["time"] += float(root.get("time", 0))
+            except:
+                pass
+
     # Playwright E2E tests (read from test-results/report.json if available)
     playwright_report_path = "playwright-test-results/report.json"
     if os.path.exists(playwright_report_path):


### PR DESCRIPTION
## Summary
- Add frontend Jest test result parsing to generate-report.py (parses frontend-test-results artifact)
- Fix Playwright report.json path in CI workflow (correct artifact structure path)

## Changes
- **generate-report.py**: Parse frontend JUnit XML from frontend-test-results directory
- **.github/workflows/ci.yml**: Correct path to Playwright report.json in artifact structure

## Test Results
After merge, 'Test Results by Module' should show:
- ✅ Backend test results (already working)
- ✅ RestAssured test results (already working)  
- ✅ Frontend test results (NOW FIXED)
- ✅ Playwright test results (NOW FIXED)

Fixes: Resolves 'all 0' values for frontend and playwright modules in GitHub Pages report